### PR TITLE
Simplify sbt script & Change Accumulator to MapReduce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 target/
 
+*.swp
+
 SpectralLDA-Tensor/src/main/scala/edu/uci/eecs/spectralLDA/LDAExample.scala
 
 src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA_old.scala

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ version := "1.0"
 scalaVersion := "2.10.6"
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
-ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 
 scalacOptions :=  Seq(
   "-unchecked",
@@ -22,62 +21,42 @@ scalacOptions :=  Seq(
   "-Yinline"
 )
 
+// Spark relies on a certain version of breeze, we avoid interfering
+// with the built-in version, which could otherwise break down
+// the code
 
-libraryDependencies ++= Seq(
-  "org.scalanlp" %% "breeze" % "0.11.2",
-  "org.scalanlp" %% "breeze-natives" % "0.11.2",
-  "org.scalanlp" %% "breeze-viz" % "0.11.2"
-)
+// If from a certain version, Spark no longer relies on breeze, we need
+// to activate the following lines
 
-libraryDependencies += "com.nativelibs4java" %% "scalaxy-loops" % "0.3.4"
+//libraryDependencies ++= Seq(
+//  "org.scalanlp" %% "breeze" % "[0.11.2,)",
+//  "org.scalanlp" %% "breeze-natives" % "[0.11.2,)"
+//)
 
-libraryDependencies += "org.apache.commons" % "commons-math3" % "3.0"
+libraryDependencies += "com.nativelibs4java" %% "scalaxy-loops" % "[0.3.4,)"
 
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.3.0"
-
-libraryDependencies += "com.github.fommil.netlib" % "all" % "1.1.2"
+libraryDependencies += "com.github.scopt" %% "scopt" % "[3.3.0,)"
 
 
 
 {
-  val defaultSparkVersion = "1.5.1"
+  val defaultSparkVersion = "[1.5.1,)"
   val sparkVersion =
     scala.util.Properties.envOrElse("SPARK_VERSION", defaultSparkVersion)
-  val excludeHadoop = ExclusionRule(organization = "org.apache.hadoop")
-  val excludeSpark = ExclusionRule(organization = "org.apache.spark")
+
   libraryDependencies ++= Seq(
-    "org.apache.spark" %% "spark-core" % sparkVersion excludeAll(excludeHadoop),
-    "org.apache.spark" %% "spark-mllib" % sparkVersion excludeAll(excludeHadoop),
-    "org.apache.spark" %% "spark-sql" % sparkVersion excludeAll(excludeHadoop)
+    "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+    "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided",
+    "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
   )
 }
 
 {
-  val defaultHadoopVersion = "0.20.2-cdh3u6"
+  val defaultHadoopVersion = "[2.6.0,)"
   val hadoopVersion =
     scala.util.Properties.envOrElse("SPARK_HADOOP_VERSION", defaultHadoopVersion)
   libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion
 }
-
-
-resolvers ++= Seq(
-  "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2/repository",
-  "Typesafe" at "http://repo.typesafe.com/typesafe/releases",
-  "Cloudera Repository" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
-  "Spray" at "http://repo.spray.cc"
-)
-
-resolvers += Resolver.sonatypeRepo("public")
-
-
-resolvers ++= Seq(
-  // other resolvers here
-  // if you want to use snapshot builds (currently 0.12-SNAPSHOT), use this.
-  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
-  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
-)
-
-
 
 mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
   {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -27,7 +27,11 @@ class TensorLDA(sc:SparkContext, paths: Seq[String], stopwordFile: String, libsv
   }
   val numDocs: Long = documents.count()
   println("Finished reading data.")
-  private val myData: DataCumulant = new DataCumulant(sc, dimK, alpha0, tolerance, documents,dimVocab,numDocs)
+  private val myData: DataCumulant = DataCumulant.getDataCumulant(sc,
+    dimK, alpha0,
+    tolerance,
+    documents,
+    dimVocab, numDocs)
 
   def runALS(maxIterations: Int): (DenseMatrix[Double], DenseVector[Double])={
     val myALS: ALS = new ALS(dimK, myData)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -14,82 +14,133 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.{Accumulator, SparkContext}
 import scala.collection.mutable
 
-class DataCumulant(sc: SparkContext, dimK: Int, alpha0: Double, tolerance: Double, documents:RDD[(Long, Double, SparseVector[Double])],dimVocab: Int,numDocs: Long ) extends Serializable {
+import scalaxy.loops._
+import scala.language.postfixOps
 
-  private val M1: Accumulator[DenseVector[Double]] = sc.accumulator(breeze.linalg.DenseVector.zeros[Double](dimVocab))(DenseVectorAccumulatorParam)
-  println("Start calculating first order moments...")
-  documents.foreach { case (_, length, vec) => M1 += update_firstOrderMoments(dimVocab, vec.toDenseVector, length) }
-  private val firstOrderMoments: DenseVector[Double] = M1.value.map(x => x / numDocs.toDouble)
-  println("Finished calculating first order moments.")
-
-  val (thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double]) = {
-    import scalaxy.loops._
-    import scala.language.postfixOps
+case class DataCumulant(thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double])
+  extends Serializable
 
 
+object DataCumulant {
+  def getDataCumulant(sc: SparkContext,
+                      dimK: Int, alpha0: Double, tolerance: Double,
+                      documents: RDD[(Long, Double, SparseVector[Double])],
+                      dimVocab: Int,
+                      numDocs: Long ): DataCumulant = {
+    println("Start calculating first order moments...")
+    val M1: DenseVector[Double] = documents map {
+      case (_, length, vec) => update_firstOrderMoments(dimVocab, vec.toDenseVector, length)
+    } reduce (_ + _)
+
+    val firstOrderMoments: DenseVector[Double] = M1 / numDocs.toDouble
+    println("Finished calculating first order moments.")
+
+    val (thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double]) = computeThirdOrderMoments(
+      sc, alpha0, dimVocab, dimK,
+      numDocs, firstOrderMoments, documents,
+      tolerance
+    )
+
+    new DataCumulant(thirdOrderMoments, unwhiteningMatrix)
+  }
+
+  private def computeThirdOrderMoments(sc: SparkContext,
+                                       alpha0: Double,
+                                       dimVocab: Int, dimK: Int,
+                                       numDocs: Long,
+                                       firstOrderMoments: DenseVector[Double],
+                                       documents: RDD[(Long, Double, SparseVector[Double])],
+                                       tolerance: Double)
+  : (DenseMatrix[Double], DenseMatrix[Double]) = {
     println("Start calculating second order moments...")
-    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = whiten(sc, alpha0, dimVocab, dimK, numDocs, firstOrderMoments, documents)
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = whiten(sc, alpha0,
+      dimVocab, dimK, numDocs, firstOrderMoments, documents)
     println("Finished calculating second order moments and whitening matrix.")
 
     println("Start whitening data with dimensionality reduction...")
-    val whitenedData: RDD[(breeze.linalg.DenseVector[Double], Double)] = documents.map {
-      case (_, length, vec) => (project(dimVocab, dimK, alpha0, eigenValues, eigenVectors, vec), length)
+    val whitenedData: RDD[(DenseVector[Double], Double)] = documents.map {
+      case (_, length, vec) => (project(dimVocab, dimK, alpha0, eigenValues, eigenVectors, vec)(tolerance), length)
     }
-    val firstOrderMoments_whitened: DenseVector[Double] = whitenedData.map(x => x._1 / x._2).reduce((a, b) => a :+ b).map(x => x / numDocs.toDouble)
+    val firstOrderMoments_whitened: DenseVector[Double] = whitenedData
+      .map(x => x._1 / x._2)
+      .reduce((a, b) => a :+ b)
+      .map(x => x / numDocs.toDouble)
     println("Finished whitening data.")
 
     println("Start calculating third order moments...")
-    var Ta: Accumulator[DenseMatrix[Double]] = sc.accumulator(breeze.linalg.DenseMatrix.zeros[Double](dimK, dimK * dimK))(DenseMatrixAccumulatorParam)
-    whitenedData.foreach{ case (vec, len) => Ta += update_thirdOrderMoments(dimK, alpha0, firstOrderMoments_whitened, vec, len)}
+    var Ta: DenseMatrix[Double] = whitenedData map {
+      case (vec, len) => update_thirdOrderMoments(
+        dimK, alpha0,
+        firstOrderMoments_whitened,
+        vec, len)
+    } reduce(_ + _)
 
     val alpha0sq: Double = alpha0 * alpha0
     val Ta_shift = DenseMatrix.zeros[Double](dimK, dimK * dimK)
     for (id_i <- 0 until dimK optimized) {
       for (id_j <- 0 until dimK optimized) {
         for (id_l <- 0 until dimK optimized) {
-          Ta_shift(id_i, id_j * dimK + id_l) += alpha0sq * firstOrderMoments_whitened(id_i) * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l)
+          Ta_shift(id_i, id_j * dimK + id_l) += (alpha0sq * firstOrderMoments_whitened(id_i)
+              * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l))
         }
       }
     }
     println("Finished calculating third order moments.")
     val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
-    (Ta.value.map(x => x / numDocs.toDouble) - Ta_shift, unwhiteningMatrix)
+    (Ta / numDocs.toDouble - Ta_shift, unwhiteningMatrix)
   }
 
-  private def whiten(sc: SparkContext, alpha0: Double, vocabSize: Int, dimK: Int, numDocs: Long, firstOrderMoments: breeze.linalg.DenseVector[Double], documents: RDD[(Long, Double, breeze.linalg.SparseVector[Double])]): (breeze.linalg.DenseMatrix[Double], breeze.linalg.DenseVector[Double]) = {
+  private def whiten(sc: SparkContext,
+                     alpha0: Double,
+                     vocabSize: Int, dimK: Int,
+                     numDocs: Long,
+                     firstOrderMoments: DenseVector[Double],
+                     documents: RDD[(Long, Double, SparseVector[Double])])
+  : (DenseMatrix[Double], DenseVector[Double]) = {
     val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
     val para_shift: Double = alpha0
 
     val SEED_random: Long = System.currentTimeMillis
     val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2, SEED_random)
     val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
-
     val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
-    // val documents_broadcasted: Broadcast[Array[(Long, Double, breeze.linalg.SparseVector[Double])]] = sc.broadcast(documents.collect())
-    val M2_a_S: Accumulator[breeze.linalg.DenseMatrix[Double]] = sc.accumulator(breeze.linalg.DenseMatrix.zeros[Double](vocabSize, dimK * 2), "Second Order Moment multiplied with S: M2_a * S")(DenseMatrixAccumulatorParam)
-    documents.foreach(this_document => M2_a_S += accumulate_M_mul_S(vocabSize, dimK * 2, alpha0, firstOrderMoments_broadcasted.value, gaussianRandomMatrix_broadcasted.value, this_document._3, this_document._2))
 
-    M2_a_S.value *= para_main
+    val M2_a_S: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize, dimK * 2,
+        alpha0,
+        firstOrderMoments_broadcasted.value,
+        gaussianRandomMatrix_broadcasted.value,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+
+    M2_a_S :*= para_main
     val shiftedMatrix: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * gaussianRandomMatrix)
-    M2_a_S.value -= shiftedMatrix :* para_shift
+    M2_a_S -= shiftedMatrix :* para_shift
 
-    val Q = AlgebraUtil.orthogonalizeMatCols(M2_a_S.value)
-    val M2_a_Q: Accumulator[DenseMatrix[Double]] = sc.accumulator(breeze.linalg.DenseMatrix.zeros[Double](vocabSize, dimK * 2), "Second Order Moment multiplied with S: M2_a * S")(DenseMatrixAccumulatorParam)
+    val Q = AlgebraUtil.orthogonalizeMatCols(M2_a_S)
 
-    documents.foreach(this_document => M2_a_Q += accumulate_M_mul_S(vocabSize, dimK * 2, alpha0, firstOrderMoments, Q, this_document._3, this_document._2))
-    M2_a_Q.value *= para_main
+    val M2_a_Q: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize,
+        dimK * 2, alpha0,
+        firstOrderMoments_broadcasted.value,
+        Q,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+    M2_a_Q :*= para_main
     val shiftedMatrix2: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * Q)
-    M2_a_Q.value -= shiftedMatrix2 :* para_shift
+    M2_a_Q -= shiftedMatrix2 :* para_shift
 
     // Note: eigenvectors * Diag(eigenvalues) = M2_a_Q
-    val svd.SVD(u: breeze.linalg.DenseMatrix[Double], s: breeze.linalg.DenseVector[Double], v: breeze.linalg.DenseMatrix[Double]) = svd((M2_a_Q.value.t * M2_a_Q.value))
-    val eigenVectors: DenseMatrix[Double] = (M2_a_Q.value * u) * breeze.linalg.diag(s.map(entry => 1.0 / math.sqrt(entry)))
+    val svd.SVD(u: breeze.linalg.DenseMatrix[Double], s: breeze.linalg.DenseVector[Double], v: breeze.linalg.DenseMatrix[Double]) = svd(M2_a_Q.t * M2_a_Q)
+    val eigenVectors: DenseMatrix[Double] = (M2_a_Q * u) * breeze.linalg.diag(s.map(entry => 1.0 / math.sqrt(entry)))
     val eigenValues: DenseVector[Double] = s.map(entry => math.sqrt(entry))
     (eigenVectors(::, 0 until dimK), eigenValues(0 until dimK))
   }
 
   private def update_firstOrderMoments(dim: Int, Wc: breeze.linalg.DenseVector[Double], len: Double) = {
-    val M1: DenseVector[Double] = Wc.map(x => x/len)
+    val M1: DenseVector[Double] = Wc / len
     M1
   }
 
@@ -158,8 +209,11 @@ class DataCumulant(sc: SparkContext, dimK: Int, alpha0: Double, tolerance: Doubl
   }
 
   private def project(dimVocab: Int, dimK: Int, alpha0: Double,
-              eigenValues: breeze.linalg.DenseVector[Double], eigenVectors: breeze.linalg.DenseMatrix[Double],
-              Wc: breeze.linalg.SparseVector[Double]): breeze.linalg.DenseVector[Double] = {
+                      eigenValues: breeze.linalg.DenseVector[Double],
+                      eigenVectors: breeze.linalg.DenseMatrix[Double],
+                      Wc: breeze.linalg.SparseVector[Double])
+                     (implicit tolerance: Double)
+  : breeze.linalg.DenseVector[Double] = {
     var offset = 0
     val result = breeze.linalg.DenseVector.zeros[Double](dimK)
     while (offset < Wc.activeSize) {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -5,7 +5,9 @@ package edu.uci.eecs.spectralLDA.utils
  * Created by furongh on 11/2/15.
  */
 
-import breeze.linalg.{DenseMatrix, DenseVector}
+import breeze.linalg._
+import breeze.numerics._
+
 import scalaxy.loops._
 import scala.language.postfixOps
 
@@ -60,9 +62,10 @@ object AlgebraUtil{
 
   def matrixNormalization(B: DenseMatrix[Double]): DenseMatrix[Double] = {
     val A: DenseMatrix[Double] = B.copy
+    val colNorms: DenseVector[Double] = sqrt(diag(A.t * A))
+
     for (i <- 0 until A.cols optimized) {
-      val thisnorm: Double = Math.sqrt(A(::, i) dot A(::, i))
-      A(::, i) :*= (if (thisnorm > TOLERANCE) (1.0 / thisnorm) else TOLERANCE)
+      A(::, i) :*= (if (colNorms(i) > TOLERANCE) (1.0 / colNorms(i)) else TOLERANCE)
     }
     return A
   }


### PR DESCRIPTION
In this PR

1. We simplify the `build.sbt` to the bare minimum, whilst always using the latest versions of dependent packages. (Instead of specifying `package % "vv.vvv"`, we specify `package % "[vv.vvv,)"`, which means the latest version after `vv.vvv`.)

2. To one's surprise, `build.sbt` won't explicitly depend on breeze, as Spark will introduce breeze as dependency. Explicit inclusion of breeze in `build.sbt` may interfere with Spark's built-in version after `sbt assembly` and break the application. However if from a certain version Spark no longer depends on breeze, we shall include it in `build.sbt`.

2. Replace all usage of `Accumulator` in `datamoments/DataCumulant.scala` by MapReduce, for which we had to split out the serialisable part of `DataCumulant` from the unserialisable part. They're now defined as case class and object respectively.

3. Tiny change of lines doing matrix operation 