### PR TITLE
add 2-wise independent hash functions and tensor sketching facility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,10 +33,12 @@ scalacOptions :=  Seq(
 //  "org.scalanlp" %% "breeze-natives" % "[0.11.2,)"
 //)
 
-libraryDependencies += "com.nativelibs4java" %% "scalaxy-loops" % "[0.3.4,)"
-
-libraryDependencies += "com.github.scopt" %% "scopt" % "[3.3.0,)"
-
+libraryDependencies ++= Seq(
+    "com.nativelibs4java" %% "scalaxy-loops" % "[0.3.4,)",
+    "com.github.scopt" %% "scopt" % "[3.3.0,)",
+    "org.scalatest" %% "scalatest" % "[2.2.6,)" % "test",
+    "org.scalatest" %% "scalatest-matchers" % "[2.2.6,)" % "test"
+)
 
 
 {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
@@ -1,0 +1,42 @@
+package edu.uci.eecs.spectralLDA.sketch
+
+import breeze.math._
+import breeze.linalg._
+import breeze.stats.distributions._
+import breeze.storage.Zero
+import org.apache.commons.math3.random.MersenneTwister
+
+/** Generate independent hash functions h and sign functions \xi */
+object HashFunctions {
+  def apply[@specialized(Double) W : Numeric : Semiring : Zero](n: Seq[Int],
+                                b: Int,
+                                B: Int,
+                                kWiseIndependent: Int = 2,
+                                seed: Option[Int] = None
+                               )
+      : (Tensor[(Int, Int, Int), W], Tensor[(Int, Int, Int), Int]) = {
+    // The current version only implemented for 2-wise independent hash functions
+    assert(kWiseIndependent == 2)
+
+    if (!seed.isEmpty) {
+      implicit val randBasis: RandBasis = new RandBasis(
+        new ThreadLocalRandomGenerator(new MersenneTwister(seed.get))
+      )
+    }
+
+    val uniform = new Uniform(0, 1)
+    val ev = implicitly[Numeric[W]]
+    val xiValues: Seq[W] = uniform.sample(B * n.sum) map { r => ev.fromInt((2 * r).toInt * 2 - 1) }
+    val hValues: Seq[Int] = uniform.sample(B * n.sum) map { r => (b * r).toInt }
+
+    val xi: Tensor[(Int, Int, Int), W] = Counter[(Int, Int, Int), W]()
+    val h: Tensor[(Int, Int, Int), Int] = Counter[(Int, Int, Int), Int]()
+    for (hashFamilyId <- 0 until B; d <- 0 until n.size; i <- 0 until n(d)) {
+      val l = hashFamilyId * n.sum + n.slice(0, d).sum + i
+      xi((hashFamilyId, d, i)) = xiValues(l)
+      h((hashFamilyId, d, i)) = hValues(l)
+    }
+
+    (xi, h)
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -1,0 +1,146 @@
+package edu.uci.eecs.spectralLDA.sketch
+
+import breeze.math._
+import breeze.linalg._
+import breeze.numerics._
+import breeze.stats._
+import breeze.storage.Zero
+import scala.language.postfixOps
+import scala.reflect.ClassTag
+
+/** Performs tensor sketching, recovery, and convolution
+  *
+  * @tparam V value type of the input tensor
+  * @tparam W value type of the sign functions \xi and the hashes
+  * */
+trait TensorSketcher[V, W] {
+  def sketch(t: Tensor[Seq[Int], V])(implicit ev: V => W): DenseMatrix[W]
+
+  def recover(f: DenseMatrix[W])(implicit ev2: Double => V): Tensor[Seq[Int], V]
+}
+
+/** Tensor sketch for any general tensor
+  *
+  * @param n shape of the tensor [n_1, n_2, ..., n_p]
+  * @param b number of hashes
+  * @param B number of hash families
+  * @param xi the sign functions with norm 1, indexed by (hash_family_id, i, j),
+  *           where 1\le i\le p, 1\le j\le n_i
+  * @param h the index hash functions, indexed by (hash_family_id, i, j),
+  *          where 1\le i\le p, 1\le j\le n_i
+  * @tparam V value type of the input tensor
+  * @tparam W value type of the sign functions \xi and the hashes
+  */
+class TensorSketch[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
+                   @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
+        (n: Seq[Int],
+         b: Int = Math.pow(2, 12).toInt,
+         B: Int = 1,
+         xi: Tensor[(Int, Int, Int), W],
+         h: Tensor[(Int, Int, Int), Int])
+  extends TensorSketcher[V, W] {
+  // order of the tensor
+  val p: Int = n.size
+
+  /** Apply the B hash families on a given tensor to sketch */
+  override def sketch(a: Tensor[Seq[Int], V])(implicit ev: V => W): DenseMatrix[W] = {
+    // We need to perform a check to ensure a's dimensions are equal to n
+    // but Breeze has no such support as of 02/2016
+    //assert(a.dimensions == n)
+
+    // Generate cartesian product of index ranges along all dimensions
+    // [1,n_1]x[1,n_2]x...x[1,n_p], for iteration later on
+    val indexRanges = n map { d => Range(0, d) }
+    val multiIndexRange = cartesianProduct[Int](indexRanges)
+
+    val evW = implicitly[Numeric[W]]
+    import evW._
+    val result = DenseMatrix.zeros[W](B, b)
+
+    for (hashFamilyId <- 0 until B; tensorIndex <- multiIndexRange) {
+      // For each index from the cartesian space [1,n_1]x[1,n_2]x...x[1,n_p]
+      // compute the contribution of the tensor's element to the final hashes
+      val hashedIndex: Int = (
+        (0 until p) map {
+          d => h((hashFamilyId, d, tensorIndex(d)))
+        } sum
+        ) % b
+      val hashedCoeffs = (0 until p) map {
+        d => xi((hashFamilyId, d, tensorIndex(d)))
+      }
+
+      result(hashFamilyId, hashedIndex) += hashedCoeffs.product * ev(a(tensorIndex))
+    }
+
+    result
+  }
+
+  override def recover(f: DenseMatrix[W])(implicit ev2: Double => V): Tensor[Seq[Int], V] = {
+    val tensor: Tensor[Seq[Int], V] = Counter[Seq[Int], V]()
+
+    // Generate cartesian product of index ranges along all dimensions
+    // [1,n_1]x[1,n_2]x...x[1,n_p], for iteration later on
+    val indexRanges = n map { d => Range(0, d) }
+    val multiIndexRange = cartesianProduct[Int](indexRanges)
+
+    val evW = implicitly[Numeric[W]]
+    import evW._
+
+    for (tensorIndex <- multiIndexRange) {
+      val seq: Seq[Double] = for {
+          hashFamilyId <- 0 until B
+
+          hashedIndex = (
+            (0 until p) map {
+              d => h((hashFamilyId, d, tensorIndex(d)))
+            } sum
+            ) % b
+
+          hashedCoeffs = (0 until p) map {
+            d => xi((hashFamilyId, d, tensorIndex(d)))
+          }
+        } yield evW.toDouble(hashedCoeffs.product * f(hashFamilyId, hashedIndex))
+
+      tensor(tensorIndex) = ev2(median(DenseVector(seq: _*)))
+    }
+
+    tensor
+  }
+
+  def sketch(v: Vector[V], d: Int)(ev: V => W): DenseMatrix[W] = {
+    assert(v.size == n(d))
+
+    val evW = implicitly[Numeric[W]]
+    import evW._
+    val result = DenseMatrix.zeros[W](B, b)
+
+    for (hashFamilyId <- 0 until B; i <- 0 until n(d)) {
+      val hashedIndex: Int = h((hashFamilyId, d, i))
+      val hashCoeff: W = xi((hashFamilyId, d, i))
+      result(hashFamilyId, hashedIndex) += hashCoeff * ev(v(i))
+    }
+
+    result
+  }
+
+  private def cartesianProduct[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] = {
+    xs.foldLeft(Seq(Seq.empty[A])){
+      (x, y) => for (a <- x.view; b <- y) yield a :+ b
+    }
+  }
+}
+
+object TensorSketch {
+  def apply[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
+            @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
+          (n: Seq[Int],
+           b: Int = Math.pow(2, 12).toInt,
+           B: Int = 1,
+           kWiseIndependent: Int = 2,
+           seed: Option[Int] = None)
+          : TensorSketch[V, W] =  {
+    val (xi: Tensor[(Int, Int, Int), W], h: Tensor[(Int, Int, Int), Int]) =
+      HashFunctions[W](n, b, B, kWiseIndependent, seed)
+    new TensorSketch[V, W](n, b, B, xi, h)
+  }
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
@@ -1,0 +1,96 @@
+package edu.uci.eecs.spectralLDA.sketch
+
+import breeze.linalg._
+import breeze.stats.distributions._
+import breeze.math._
+import breeze.numerics._
+import org.scalatest._
+import org.scalatest.Matchers._
+
+
+class TensorSketchTest extends FlatSpec with Matchers {
+  "A 2x2x2 tensor's sketch" should "be correct" in {
+    val n: Seq[Int] = Seq(2, 2, 2)
+    val b = 4
+    val B = 3
+
+    val xi: Tensor[(Int, Int, Int),Double] = Counter(
+      (0,2,1) -> -1.0, (1,1,1) -> 1.0, (2,2,1) -> 1.0,
+      (1,1,0) -> 1.0, (2,0,0) -> 1.0, (0,1,0) -> 1.0,
+      (0,0,0) -> -1.0, (0,1,1) -> 1.0, (1,2,1) -> -1.0,
+      (2,0,1) -> -1.0, (1,2,0) -> -1.0, (0,0,1) -> 1.0,
+      (2,2,0) -> 1.0, (2,1,1) -> 1.0, (0,2,0) -> -1.0,
+      (1,0,0) -> -1.0, (1,0,1) -> -1.0, (2,1,0) -> 1.0
+    )
+    val h: Tensor[(Int, Int, Int),Int] = Counter(
+      (0,2,1) -> 1, (1,1,1) -> 0, (2,2,1) -> 2,
+      (1,1,0) -> 3, (2,0,0) -> 1, (0,1,0) -> 0,
+      (0,0,0) -> 1, (0,1,1) -> 3, (1,2,1) -> 1,
+      (2,0,1) -> 2, (1,2,0) -> 2, (0,0,1) -> 3,
+      (2,2,0) -> 0, (2,1,1) -> 2, (0,2,0) -> 1,
+      (1,0,0) -> 1, (1,0,1) -> 0, (2,1,0) -> 2
+    )
+    val sketch = new TensorSketch[Double, Double](n, b, B, xi, h)
+
+    val a: Tensor[Seq[Int], Double] = Counter(
+      Seq(0,0,0) -> 3, Seq(0,1,0) -> 5, Seq(1,0,0) -> 7,
+      Seq(1,1,0) -> 9, Seq(0,0,1) -> 2, Seq(0,1,1) -> 4,
+      Seq(1,0,1) -> 6, Seq(1,1,1) -> 8
+    )
+
+    val s = sketch.sketch(a)
+    val recovered_a = sketch.recover(s)
+
+    s should equal (new DenseMatrix[Double](3, 4,
+      Array[Double](-13, 6, -16, 9, 17, 6,
+        5, 16, -14, -17, 5, 8)
+    ))
+    recovered_a should equal (Counter(
+      List(0, 1, 1) -> 9.0, List(0, 0, 0) -> 8.0, List(1, 1, 0) -> 16.0,
+      List(1, 0, 0) -> 16.0, List(0, 1, 0) -> 8.0, List(1, 0, 1) -> 13.0,
+      List(1, 1, 1) -> 17.0, List(0, 0, 1) -> 6.0
+    ))
+  }
+
+  "Two 10x10x10 random tensors' sketches inner product" should "be close to the tensors' inner product" in {
+    val n: Seq[Int] = Seq(10, 10, 10)
+    val b = 32
+    val B = 40
+
+    val sketch = TensorSketch[Double, Double](n, b, B)
+
+    // Two uniformly random tensors
+    val t1: Tensor[Seq[Int], Double] = Counter()
+    val t2: Tensor[Seq[Int], Double] = Counter()
+
+    val uniform = new Uniform(0.0, 0.5)
+    val u1 = uniform.sample(n(0))
+    val u2 = uniform.sample(n(0))
+    for (i <- 0 until n(0)) {
+      for (j <- 0 until n(1)) {
+        for (k <- 0 until n(2)) {
+          t1(Seq(i, j, k)) = u1(i) * u1(j) * u1(k)
+          if (i <= j && j <= k)
+            t2(Seq(i, j, k)) = u2(i) * u2(j) * u2(k)
+        }
+      }
+    }
+
+    // Sketch and compare the inner products
+    val s1 = sketch.sketch(t1)
+    val s2 = sketch.sketch(t2)
+
+    val innerProductTensors = sum(
+      for {
+        i <- 0 until n(0)
+        j <- 0 until n(1)
+        k <- 0 until n(2)
+      } yield t1(Seq(i, j, k)) * t2(Seq(i, j, k))
+    )
+    val innerProductSketches = sum(s1 :* s2) / B
+
+    val delta = innerProductSketches - innerProductTensors
+    info("Difference of inner products: %f" format delta)
+    abs(delta) should be <= 0.05
+  }
+}


### PR DESCRIPTION
We begin to add sketch-based Tensor LDA algorithms

1. Add class `TensorSketch` which sketches a tensor, or recovers a tensor from its count sketch
2. Add class `HashFunctions` which generates a family of random hash functions. For now they're limited to 2-wise independent hash functions
3. Add test cases for these functionalities. We could do `sbt "+ test"` to invoke the tests