### PR TITLE
Add sketch-based ALS

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -1,0 +1,211 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+/**
+  * Tensor Decomposition Algorithms.
+  * Alternating Least Square algorithm is implemented.
+  */
+import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
+import edu.uci.eecs.spectralLDA.datamoments.DataCumulantSketch
+import breeze.linalg.{*, DenseMatrix, DenseVector}
+import breeze.signal.{fourierTr, iFourierTr}
+import breeze.math.Complex
+import breeze.stats.median
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.apache.spark.SparkContext
+
+import scalaxy.loops._
+import scala.language.postfixOps
+import scala.util.control.Breaks._
+
+class ALSSketch(dimK: Int,
+                myDataSketch: DataCumulantSketch,
+                sketcher: TensorSketcher[Double, Double]) extends Serializable {
+
+  def run(sc:SparkContext,
+          maxIterations: Int)
+        : (DenseMatrix[Double], DenseVector[Double])={
+    val sketch_T: DenseMatrix[Double] = myDataSketch.thirdOrderMomentsSketch
+    val unwhiteningMatrix: DenseMatrix[Double] = myDataSketch.unwhiteningMatrix
+
+    val SEED_A: Long = System.currentTimeMillis
+    val SEED_B: Long = System.currentTimeMillis
+    val SEED_C: Long = System.currentTimeMillis
+
+    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_A)
+    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_B)
+    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_C)
+
+    var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
+    var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)
+    var iter: Int = 0
+
+    println("Start ALS iterations...")
+
+    while ((iter == 0) || ((iter < maxIterations) && !AlgebraUtil.isConverged(A_prev, A))) {
+      A_prev = A.copy
+
+      // println("Mode A...")
+      A = updateALSiteration(sketch_T, B, C, sketcher)
+      lambda = AlgebraUtil.colWiseNorm2(A)
+      A = AlgebraUtil.matrixNormalization(A)
+
+      // println("Mode B...")
+      B = updateALSiteration(sketch_T, C, A, sketcher)
+      B = AlgebraUtil.matrixNormalization(B)
+
+      // println("Mode C...")
+      C = updateALSiteration(sketch_T, A, B, sketcher)
+      C = AlgebraUtil.matrixNormalization(C)
+
+      iter += 1
+    }
+    println("Finished ALS iterations.")
+
+    val whitenedTopicWordMatrix: DenseMatrix[Double] = unwhiteningMatrix * A.copy
+    val alpha: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
+    val topicWordMatrix: breeze.linalg.DenseMatrix[Double] = whitenedTopicWordMatrix * breeze.linalg.diag(lambda)
+    val topicWordMatrix_normed: breeze.linalg.DenseMatrix[Double] = simplexProj_Matrix(topicWordMatrix)
+    (topicWordMatrix_normed, alpha)
+  }
+
+  private def updateALSiteration(sketch_T: DenseMatrix[Double],
+                                 B: DenseMatrix[Double],
+                                 C: DenseMatrix[Double],
+                                 sketcher: TensorSketcher[Double, Double])
+          : DenseMatrix[Double] = {
+    // pinv((C^T C) :* (B^T B))
+    val Inverted: DenseMatrix[Double] = AlgebraUtil.to_invert(C, B)
+
+    // T(C katri-rao dot B)
+    val TIBC: DenseMatrix[Double] = TensorSketchOps.TIUV(sketch_T, B, C, sketcher)
+
+    // T * (C katri-rao dot B) * pinv((C^T C) :* (B^T B))
+    // i.e T * pinv((C katri-rao dot B)^T)
+    Inverted * TIBC
+  }
+
+  private def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
+    val M_onSimplex: DenseMatrix[Double] = DenseMatrix.zeros[Double](M.rows, M.cols)
+    for(i <- 0 until M.cols optimized){
+      val thisColumn = M(::,i)
+
+      val tmp1 = simplexProj(thisColumn)
+      val tmp2 = simplexProj(-thisColumn)
+      val err1:Double = breeze.linalg.norm(tmp1 - thisColumn)
+      val err2:Double = breeze.linalg.norm(tmp2 - thisColumn)
+      if(err1 > err2){
+        M_onSimplex(::,i) := tmp2
+      }
+      else{
+        M_onSimplex(::,i) := tmp1
+      }
+    }
+    M_onSimplex
+  }
+
+  private def simplexProj(V: DenseVector[Double]): DenseVector[Double]={
+    // val z:Double = 1.0
+    val len: Int = V.length
+    val U: DenseVector[Double] = DenseVector(V.copy.toArray.sortWith(_ > _))
+    val cums: DenseVector[Double] = DenseVector(AlgebraUtil.Cumsum(U.toArray).map(x => x-1))
+    val Index: DenseVector[Double] = DenseVector((1 to (len + 1)).toArray.map(x => 1.0/x.toDouble))
+    val InterVec: DenseVector[Double] = cums :* Index
+    val TobefindMax: DenseVector[Double] = U - InterVec
+    var maxIndex : Int = 0
+    // find maxIndex
+    breakable{
+      for (i <- 0 until len optimized){
+        if (TobefindMax(len - i - 1) > 0){
+          maxIndex = len - i - 1
+          break()
+        }
+      }
+    }
+    val theta: Double = InterVec(maxIndex)
+    val W: DenseVector[Double] = V.map(x => x - theta)
+    val P_norm: DenseVector[Double] = W.map(x => if (x > 0) x else 0)
+    P_norm
+  }
+
+}
+
+private object TensorSketchOps {
+  /** Compute T(I, u, v) given the fft of sketch_T
+    *
+    * T is an n-by-n-by-n tensor, for the orthogonalised M3
+    *
+    * @param fft_sketch_T fft of sketch_T, with B rows where B is the number of hash families
+    * @param u length-n vector
+    * @param v length-n vector
+    * @param sketcher count sketcher on n-by-n-by-n tensors
+    * @return length-n vector for T(I, u, v)
+    */
+  private def TIuv(fft_sketch_T: DenseMatrix[Complex],
+                   u: DenseVector[Double],
+                   v: DenseVector[Double],
+                   sketcher: TensorSketcher[Double, Double])
+      : DenseVector[Double] = {
+    val n = u.length
+
+    val sketch_u: DenseMatrix[Double] = sketcher.sketch(u, 1)
+    val sketch_v: DenseMatrix[Double] = sketcher.sketch(v, 2)
+
+    val all_inner_prod: DenseMatrix[Complex] = DenseMatrix.zeros[Complex](sketcher.B, n)
+
+    for (hashFamilyId <- 0 until sketcher.B) {
+      val fft_sketch_u = fourierTr(sketch_u(hashFamilyId, ::)).toDenseVector
+      val fft_sketch_v = fourierTr(sketch_v(hashFamilyId, ::)).toDenseVector
+
+      // one-row matrix for conj(fft(sketch_{2,u})) :* conj(fft(sketch_{3,v}))
+      val prod_conj_fft: DenseMatrix[Complex] = fft_sketch_u.t :* fft_sketch_v.t
+
+      // one-row matrix for fft(sketch_T) :* conj(fft(sketch_{2,u})) :* conj(fft(sketch_{3,v}))
+      val prod: DenseMatrix[Complex] = fft_sketch_T(hashFamilyId to hashFamilyId, ::) :* prod_conj_fft
+
+      // ifft(fft(sketch_T) :* conj(fft(sketch_{2,u})) :* conj(fft(sketch_{3,v})))
+      // aka l.h.s of the dot product for TIuv
+      val TIuv_lhs: DenseVector[Complex] = iFourierTr(prod.toDenseVector)
+
+      // dot_product(ifft(fft(sketch_T) :* conj(fft(sketch_{2,u})) :* conj(fft(sketch_{3,v}))), sketch_{e_i})
+      // for all i, 1\le i\le n
+      for (i <- 0 until n) {
+        all_inner_prod(hashFamilyId to hashFamilyId, i) := (TIuv_lhs(sketcher.h((hashFamilyId, 0, i)))
+                                                              * sketcher.xi((hashFamilyId, 0, i)))
+      }
+    }
+
+    val result = for {
+        i <- 0 until n
+    } yield median(all_inner_prod(::, i) map { _.re })
+
+    DenseVector(result: _*)
+  }
+
+  /** Compute the matrix {T(I, U_i, V_i), 1\le i\le k} given sketch_T
+    *
+    * T is an n-by-n-by-n tensor, for the orthogonalised M3
+    *
+    * @param sketch_T sketch of T, with B rows where B is the number of hash families
+    * @param U n-by-k matrix
+    * @param V n-by-k matrix
+    * @param sketcher count sketcher on n-by-n-by-n tensors
+    * @return n-by-k matrix for {T(I, U_i, V_i), 1\le i\le k}
+    */
+  def TIUV(sketch_T: DenseMatrix[Double],
+           U: DenseMatrix[Double],
+           V: DenseMatrix[Double],
+           sketcher: TensorSketcher[Double, Double])
+      : DenseMatrix[Double] = {
+    assert((U.rows == V.rows) && (U.cols == V.cols))
+    assert(sketcher.n(0) == U.rows)
+
+    val fft_sketch_T: DenseMatrix[Complex] = fourierTr(sketch_T(*, ::))
+
+    val result: DenseMatrix[Double] = DenseMatrix.zeros[Double](U.rows, U.cols)
+    for (j <- 0 until U.cols) {
+      result(::, j) := TIuv(fft_sketch_T, U(::, j), V(::, j), sketcher)
+    }
+
+    result
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -1,0 +1,35 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+/**
+  * Tensor Decomposition Algorithms.
+  * Alternating Least Square algorithm is implemented.
+  */
+import edu.uci.eecs.spectralLDA.datamoments.{DataCumulant, DataCumulantSketch}
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, sum}
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.apache.spark.rdd.RDD
+
+class TensorLDASketch(dimK: Int,
+                      alpha0: Double,
+                      maxIterations: Int = 1000,
+                      tolerance: Double = 1e-9,
+                      sketcher: TensorSketcher[Double, Double]) extends Serializable {
+
+  def fit(documents: RDD[(Long, SparseVector[Double])])
+  : (DenseMatrix[Double], DenseVector[Double]) = {
+    val documents_ = documents map {
+      case (id, wc) => (id, sum(wc), wc)
+    }
+
+    val myDataSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
+      dimK, alpha0,
+      tolerance,
+      documents_,
+      sketcher
+    )
+
+    val myALS: ALSSketch = new ALSSketch(dimK, myDataSketch, sketcher)
+    myALS.run(documents.sparkContext, maxIterations)
+  }
+
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -1,0 +1,235 @@
+package edu.uci.eecs.spectralLDA.datamoments
+
+/**
+  * Data Cumulants Calculation.
+  */
+
+import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
+import breeze.linalg._
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+
+import scala.collection.mutable
+import scalaxy.loops._
+import scala.language.postfixOps
+
+case class DataCumulantSketch(thirdOrderMomentsSketch: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double])
+  extends Serializable
+
+
+object DataCumulantSketch {
+  def getDataCumulant(dimK: Int,
+                      alpha0: Double,
+                      tolerance: Double,
+                      documents: RDD[(Long, Double, SparseVector[Double])],
+                      sketcher: TensorSketcher[Double, Double])
+  : DataCumulantSketch = {
+    val sc: SparkContext = documents.sparkContext
+    val dimVocab = documents.take(1)(0)._3.length
+    val numDocs = documents.count()
+
+    println("Start calculating first order moments...")
+    val M1: DenseVector[Double] = documents map {
+      case (_, length, vec) => update_firstOrderMoments(dimVocab, vec.toDenseVector, length)
+    } reduce (_ + _)
+
+    val firstOrderMoments: DenseVector[Double] = M1 / numDocs.toDouble
+    println("Finished calculating first order moments.")
+
+    val (thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double]) = computeThirdOrderMoments(
+      sc, alpha0, dimVocab, dimK,
+      numDocs, firstOrderMoments, documents,
+      tolerance
+    )
+
+    val thirdOrderMomentsSketch = sketcher.sketch(thirdOrderMoments)
+    new DataCumulantSketch(thirdOrderMomentsSketch, unwhiteningMatrix)
+  }
+
+  private def computeThirdOrderMoments(sc: SparkContext,
+                                       alpha0: Double,
+                                       dimVocab: Int, dimK: Int,
+                                       numDocs: Long,
+                                       firstOrderMoments: DenseVector[Double],
+                                       documents: RDD[(Long, Double, SparseVector[Double])],
+                                       tolerance: Double)
+  : (DenseMatrix[Double], DenseMatrix[Double]) = {
+    println("Start calculating second order moments...")
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = whiten(sc, alpha0,
+      dimVocab, dimK, numDocs, firstOrderMoments, documents)
+    println("Finished calculating second order moments and whitening matrix.")
+
+    println("Start whitening data with dimensionality reduction...")
+    val whitenedData: RDD[(DenseVector[Double], Double)] = documents.map {
+      case (_, length, vec) => (project(dimVocab, dimK, alpha0, eigenValues, eigenVectors, vec)(tolerance), length)
+    }
+    val firstOrderMoments_whitened: DenseVector[Double] = whitenedData
+      .map(x => x._1 / x._2)
+      .reduce((a, b) => a :+ b)
+      .map(x => x / numDocs.toDouble)
+    println("Finished whitening data.")
+
+    println("Start calculating third order moments...")
+    var Ta: DenseMatrix[Double] = whitenedData map {
+      case (vec, len) => update_thirdOrderMoments(
+        dimK, alpha0,
+        firstOrderMoments_whitened,
+        vec, len)
+    } reduce(_ + _)
+
+    val alpha0sq: Double = alpha0 * alpha0
+    val Ta_shift = DenseMatrix.zeros[Double](dimK, dimK * dimK)
+    for (id_i <- 0 until dimK optimized) {
+      for (id_j <- 0 until dimK optimized) {
+        for (id_l <- 0 until dimK optimized) {
+          Ta_shift(id_i, id_j * dimK + id_l) += (alpha0sq * firstOrderMoments_whitened(id_i)
+            * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l))
+        }
+      }
+    }
+    println("Finished calculating third order moments.")
+    val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
+    (Ta / numDocs.toDouble - Ta_shift, unwhiteningMatrix)
+  }
+
+  private def whiten(sc: SparkContext,
+                     alpha0: Double,
+                     vocabSize: Int, dimK: Int,
+                     numDocs: Long,
+                     firstOrderMoments: DenseVector[Double],
+                     documents: RDD[(Long, Double, SparseVector[Double])])
+  : (DenseMatrix[Double], DenseVector[Double]) = {
+    val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
+    val para_shift: Double = alpha0
+
+    val SEED_random: Long = System.currentTimeMillis
+    val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2, SEED_random)
+    val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
+    val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
+
+    val M2_a_S: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize, dimK * 2,
+        alpha0,
+        firstOrderMoments_broadcasted.value,
+        gaussianRandomMatrix_broadcasted.value,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+
+    M2_a_S :*= para_main
+    val shiftedMatrix: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * gaussianRandomMatrix)
+    M2_a_S -= shiftedMatrix :* para_shift
+
+    val Q = AlgebraUtil.orthogonalizeMatCols(M2_a_S)
+
+    val M2_a_Q: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize,
+        dimK * 2, alpha0,
+        firstOrderMoments_broadcasted.value,
+        Q,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+    M2_a_Q :*= para_main
+    val shiftedMatrix2: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * Q)
+    M2_a_Q -= shiftedMatrix2 :* para_shift
+
+    // Note: eigenvectors * Diag(eigenvalues) = M2_a_Q
+    val svd.SVD(u: breeze.linalg.DenseMatrix[Double], s: breeze.linalg.DenseVector[Double], v: breeze.linalg.DenseMatrix[Double]) = svd(M2_a_Q.t * M2_a_Q)
+    val eigenVectors: DenseMatrix[Double] = (M2_a_Q * u) * breeze.linalg.diag(s.map(entry => 1.0 / math.sqrt(entry)))
+    val eigenValues: DenseVector[Double] = s.map(entry => math.sqrt(entry))
+    (eigenVectors(::, 0 until dimK), eigenValues(0 until dimK))
+  }
+
+  private def update_firstOrderMoments(dim: Int, Wc: breeze.linalg.DenseVector[Double], len: Double) = {
+    val M1: DenseVector[Double] = Wc / len
+    M1
+  }
+
+
+  private def update_thirdOrderMoments(dimK: Int, alpha0: Double, m1: DenseVector[Double], Wc: DenseVector[Double], len: Double): DenseMatrix[Double] = {
+    val len_calibrated: Double = math.max(len, 3.0)
+
+    val scale3fac: Double = (alpha0 + 1.0) * (alpha0 + 2.0) / (2.0 * len_calibrated * (len_calibrated - 1.0) * (len_calibrated - 2.0))
+    val scale2fac: Double = alpha0 * (alpha0 + 1.0) / (2.0 * len_calibrated * (len_calibrated - 1.0))
+    val Ta = breeze.linalg.DenseMatrix.zeros[Double](dimK, dimK * dimK)
+
+    import scalaxy.loops._
+    import scala.language.postfixOps
+    for (i <- 0 until dimK optimized) {
+      for (j <- 0 until dimK optimized) {
+        for (l <- 0 until dimK optimized) {
+          Ta(i, dimK * j + l) += scale3fac * Wc(i) * Wc(j) * Wc(l)
+
+          Ta(i, dimK * j + l) -= scale2fac * Wc(i) * Wc(j) * m1(l)
+          Ta(i, dimK * j + l) -= scale2fac * Wc(i) * m1(j) * Wc(l)
+          Ta(i, dimK * j + l) -= scale2fac * m1(i) * Wc(j) * Wc(l)
+        }
+        Ta(i, dimK * i + j) -= scale3fac * Wc(i) * Wc(j)
+        Ta(i, dimK * j + i) -= scale3fac * Wc(i) * Wc(j)
+        Ta(i, dimK * j + j) -= scale3fac * Wc(i) * Wc(j)
+
+        Ta(i, dimK * i + j) += scale2fac * Wc(i) * m1(j)
+        Ta(i, dimK * j + i) += scale2fac * Wc(i) * m1(j)
+        Ta(i, dimK * j + j) += scale2fac * m1(i) * Wc(j)
+      }
+      Ta(i, dimK * i + i) += 2.0 * scale3fac * Wc(i)
+    }
+    Ta
+  }
+
+  private def accumulate_M_mul_S(dimVocab: Int, dimK: Int, alpha0: Double,
+                                 m1: breeze.linalg.DenseVector[Double], S: breeze.linalg.DenseMatrix[Double], Wc: breeze.linalg.SparseVector[Double], len: Double) = {
+    assert(dimVocab == Wc.length)
+    assert(dimVocab == m1.length)
+    assert(dimVocab == S.rows)
+    assert(dimK == S.cols)
+    val len_calibrated: Double = math.max(len, 3.0)
+
+    val M2_a = breeze.linalg.DenseMatrix.zeros[Double](dimVocab, dimK)
+
+    val norm_length: Double = 1.0 / (len_calibrated * (len_calibrated - 1.0))
+    val data_mul_S: DenseVector[Double] = breeze.linalg.DenseVector.zeros[Double](dimK)
+
+    var offset = 0
+    while (offset < Wc.activeSize) {
+      val token: Int = Wc.indexAt(offset)
+      val count: Double = Wc.valueAt(offset)
+      data_mul_S += S(token, ::).t.map(x => x * count)
+      offset += 1
+    }
+
+    offset = 0
+    while (offset < Wc.activeSize) {
+      val token: Int = Wc.indexAt(offset)
+      val count: Double = Wc.valueAt(offset)
+      M2_a(token, ::) += (data_mul_S - S(token, ::).t).map(x => x * count * norm_length).t
+
+      offset += 1
+    }
+    M2_a
+  }
+
+  private def project(dimVocab: Int, dimK: Int, alpha0: Double,
+                      eigenValues: breeze.linalg.DenseVector[Double],
+                      eigenVectors: breeze.linalg.DenseMatrix[Double],
+                      Wc: breeze.linalg.SparseVector[Double])
+                     (implicit tolerance: Double)
+  : breeze.linalg.DenseVector[Double] = {
+    var offset = 0
+    val result = breeze.linalg.DenseVector.zeros[Double](dimK)
+    while (offset < Wc.activeSize) {
+      val token: Int = Wc.indexAt(offset)
+      val count: Double = Wc.valueAt(offset)
+      // val S_row = S(token,::)
+
+      result += eigenVectors(token, ::).t.map(x => x * count)
+
+      offset += 1
+    }
+    val whitenedData = result :/ eigenValues.map(x => math.sqrt(x) + tolerance)
+    whitenedData
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -22,7 +22,7 @@ trait TensorSketcherBase[V, W] {
 /** Tensor sketching for any general tensor
   *
   * @param n shape of the tensor [n_1, n_2, ..., n_p]
-  * @param b number of hashes
+  * @param b length of a hash
   * @param B number of hash families
   * @param xi the sign functions with norm 1, indexed by (hash_family_id, i, j),
   *           where 1\le i\le p, 1\le j\le n_i
@@ -32,13 +32,14 @@ trait TensorSketcherBase[V, W] {
   * @tparam W value type of the sign functions \xi and the hashes
   */
 class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
-                     @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
-        (n: Seq[Int],
-         b: Int = Math.pow(2, 12).toInt,
-         B: Int = 1,
-         xi: Tensor[(Int, Int, Int), W],
-         h: Tensor[(Int, Int, Int), Int])
+                          @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
+        (val n: Seq[Int],
+         val b: Int = Math.pow(2, 12).toInt,
+         val B: Int = 1,
+         val xi: Tensor[(Int, Int, Int), W],
+         val h: Tensor[(Int, Int, Int), Int])
   extends TensorSketcherBase[V, W] {
+
   // order of the tensor
   val p: Int = n.size
 
@@ -128,8 +129,8 @@ class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Ze
   }
 
   /** Sketch a vector along the given dimension */
-  def sketch(v: Vector[V], d: Int)(ev: V => W): DenseMatrix[W] = {
-    assert(v.size == n(d))
+  def sketch(v: Vector[V], d: Int)(implicit ev: V => W): DenseMatrix[W] = {
+    assert(v.length == n(d))
 
     val evW = implicitly[Numeric[W]]
     import evW._
@@ -149,6 +150,10 @@ class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Ze
       (x, y) => for (a <- x.view; b <- y) yield a :+ b
     }
   }
+
+  //implicit private def d2d(a: Double): Double = { a }
+
+  //implicit private def d2c(a: Double): Complex = { Complex(a, 0.0) }
 }
 
 object TensorSketcher {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -13,13 +13,13 @@ import scala.reflect.ClassTag
   * @tparam V value type of the input tensor
   * @tparam W value type of the sign functions \xi and the hashes
   * */
-trait TensorSketcher[V, W] {
+trait TensorSketcherBase[V, W] {
   def sketch(t: Tensor[Seq[Int], V])(implicit ev: V => W): DenseMatrix[W]
 
   def recover(f: DenseMatrix[W])(implicit ev2: Double => V): Tensor[Seq[Int], V]
 }
 
-/** Tensor sketch for any general tensor
+/** Tensor sketching for any general tensor
   *
   * @param n shape of the tensor [n_1, n_2, ..., n_p]
   * @param b number of hashes
@@ -31,14 +31,14 @@ trait TensorSketcher[V, W] {
   * @tparam V value type of the input tensor
   * @tparam W value type of the sign functions \xi and the hashes
   */
-class TensorSketch[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
-                   @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
+class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
+                     @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
         (n: Seq[Int],
          b: Int = Math.pow(2, 12).toInt,
          B: Int = 1,
          xi: Tensor[(Int, Int, Int), W],
          h: Tensor[(Int, Int, Int), Int])
-  extends TensorSketcher[V, W] {
+  extends TensorSketcherBase[V, W] {
   // order of the tensor
   val p: Int = n.size
 
@@ -107,6 +107,27 @@ class TensorSketch[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero
     tensor
   }
 
+  /** sketch a matrix specifically */
+  def sketch(a: Matrix[V])(implicit ev: V => W): DenseMatrix[W] = {
+    require(p == 2)
+
+    val evW = implicitly[Numeric[W]]
+    import evW._
+    val result = DenseMatrix.zeros[W](B, b)
+
+    for (hashFamilyId <- 0 until B; i <- 0 until a.rows; j <- 0 until a.cols) {
+      // For each index from the cartesian space [1,n_1]x[1,n_2]x...x[1,n_p]
+      // compute the contribution of the tensor's element to the final hashes
+      val hashedIndex = (h((hashFamilyId, 0, i)) + h((hashFamilyId, 1, j))) % b
+      val hashedCoeff = xi((hashFamilyId, 0, i)) * xi((hashFamilyId, 1, j))
+
+      result(hashFamilyId, hashedIndex) += hashedCoeff * ev(a(i, j))
+    }
+
+    result
+  }
+
+  /** Sketch a vector along the given dimension */
   def sketch(v: Vector[V], d: Int)(ev: V => W): DenseMatrix[W] = {
     assert(v.size == n(d))
 
@@ -130,7 +151,7 @@ class TensorSketch[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero
   }
 }
 
-object TensorSketch {
+object TensorSketcher {
   def apply[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
             @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
           (n: Seq[Int],
@@ -138,9 +159,9 @@ object TensorSketch {
            B: Int = 1,
            kWiseIndependent: Int = 2,
            seed: Option[Int] = None)
-          : TensorSketch[V, W] =  {
+          : TensorSketcher[V, W] =  {
     val (xi: Tensor[(Int, Int, Int), W], h: Tensor[(Int, Int, Int), Int]) =
       HashFunctions[W](n, b, B, kWiseIndependent, seed)
-    new TensorSketch[V, W](n, b, B, xi, h)
+    new TensorSketcher[V, W](n, b, B, xi, h)
   }
 }

--- a/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
@@ -30,7 +30,7 @@ class TensorSketchTest extends FlatSpec with Matchers {
       (2,2,0) -> 0, (2,1,1) -> 2, (0,2,0) -> 1,
       (1,0,0) -> 1, (1,0,1) -> 0, (2,1,0) -> 2
     )
-    val sketch = new TensorSketch[Double, Double](n, b, B, xi, h)
+    val sketcher = new TensorSketcher[Double, Double](n, b, B, xi, h)
 
     val a: Tensor[Seq[Int], Double] = Counter(
       Seq(0,0,0) -> 3, Seq(0,1,0) -> 5, Seq(1,0,0) -> 7,
@@ -38,8 +38,8 @@ class TensorSketchTest extends FlatSpec with Matchers {
       Seq(1,0,1) -> 6, Seq(1,1,1) -> 8
     )
 
-    val s = sketch.sketch(a)
-    val recovered_a = sketch.recover(s)
+    val s = sketcher.sketch(a)
+    val recovered_a = sketcher.recover(s)
 
     s should equal (new DenseMatrix[Double](3, 4,
       Array[Double](-13, 6, -16, 9, 17, 6,
@@ -57,7 +57,7 @@ class TensorSketchTest extends FlatSpec with Matchers {
     val b = 32
     val B = 40
 
-    val sketch = TensorSketch[Double, Double](n, b, B)
+    val sketcher = TensorSketcher[Double, Double](n, b, B)
 
     // Two uniformly random tensors
     val t1: Tensor[Seq[Int], Double] = Counter()
@@ -77,8 +77,8 @@ class TensorSketchTest extends FlatSpec with Matchers {
     }
 
     // Sketch and compare the inner products
-    val s1 = sketch.sketch(t1)
-    val s2 = sketch.sketch(t2)
+    val s1 = sketcher.sketch(t1)
+    val s2 = sketcher.sketch(t2)
 
     val innerProductTensors = sum(
       for {


### PR DESCRIPTION
Similar to the `TensorLDA` class, I added `TensorLDASketch` as well as `DataCumulantSketch`, `ALSSketch`, so that at each update of ALS, `T(C khatri-rao dot B)` is computed with the FFT of the sketches.

TODO:

1. Test the correctness of sketch-based ALS
2. Add sketch when whitening M3
3. Time the algorithms

What's tricky about the test is that the randomised SVD, the ALS, and the sketching all introduce some randomness, I'll see if we could obtain stable test results. I'll slightly refactor `DataCumulant` to make it modular/portable so that we could add sketch when whitening M3. 