### PR TITLE
Spectral LDA via Sketching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Spectral LDA on Spark
 
 ## Summary 
-* This code implements a spectral (third order tensor decomposition) learning method for learning LDA topic model on Spark. 
+* This code implements a Spectral (third order tensor decomposition) learning method for learning LDA topic model on Spark.
+* We also implemented a Spectral LDA model via sketching to accelerate tensor building and decomposition.
 * Version: 1.0
 * [Learn Markdown](https://bitbucket.org/tutorials/markdowndemo)
 
@@ -49,6 +50,7 @@
 
 ## References
 * White Paper: http://newport.eecs.uci.edu/anandkumar/pubs/whitepaper.pdf
+* Fast and Guaranteed Tensor Decomposition via Sketching: http://arxiv.org/abs/1506.04448
 * New York Times Result Visualization: http://newport.eecs.uci.edu/anandkumar/Lab/Lab_sub/NewYorkTimes3.html
 
 ## Who do I talk to?

--- a/build.sbt
+++ b/build.sbt
@@ -53,12 +53,12 @@ libraryDependencies ++= Seq(
   )
 }
 
-{
-  val defaultHadoopVersion = "[2.6.0,)"
-  val hadoopVersion =
-    scala.util.Properties.envOrElse("SPARK_HADOOP_VERSION", defaultHadoopVersion)
-  libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion
-}
+//{
+//  val defaultHadoopVersion = "[2.6.0,)"
+//  val hadoopVersion =
+//    scala.util.Properties.envOrElse("SPARK_HADOOP_VERSION", defaultHadoopVersion)
+//  libraryDependencies += "org.apache.hadoop" % "hadoop-client" % hadoopVersion
+//}
 
 mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
   {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -81,7 +81,7 @@ class ALSSketch(dimK: Int,
 
     // T * (C katri-rao dot B) * pinv((C^T C) :* (B^T B))
     // i.e T * pinv((C katri-rao dot B)^T)
-    Inverted * TIBC
+    TIBC * Inverted
   }
 
   private def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -13,7 +13,8 @@ class TensorLDASketch(dimK: Int,
                       alpha0: Double,
                       maxIterations: Int = 1000,
                       tolerance: Double = 1e-9,
-                      sketcher: TensorSketcher[Double, Double]) extends Serializable {
+                      sketcher: TensorSketcher[Double, Double],
+                      nonNegativeDocumentConcentration: Boolean = true) extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
   : (DenseMatrix[Double], DenseVector[Double]) = {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -12,21 +12,17 @@ import org.apache.spark.rdd.RDD
 class TensorLDASketch(dimK: Int,
                       alpha0: Double,
                       maxIterations: Int = 1000,
-                      tolerance: Double = 1e-9,
                       sketcher: TensorSketcher[Double, Double],
                       randomisedSVD: Boolean = true,
-                      nonNegativeDocumentConcentration: Boolean = true) extends Serializable {
+                      nonNegativeDocumentConcentration: Boolean = true)
+                     (implicit tolerance: Double = 1e-9)
+  extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
   : (DenseMatrix[Double], DenseVector[Double]) = {
-    val documents_ = documents map {
-      case (id, wc) => (id, sum(wc), wc)
-    }
-
     val myDataSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
       dimK, alpha0,
-      tolerance,
-      documents_,
+      documents,
       sketcher,
       randomisedSVD = randomisedSVD
     )

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -34,7 +34,8 @@ class TensorLDASketch(dimK: Int,
       nonNegativeDocumentConcentration = nonNegativeDocumentConcentration
     )
 
-    myALS.run
+    val (beta, alpha) = myALS.run
+    (beta, alpha * alpha0)
   }
 
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -14,6 +14,7 @@ class TensorLDASketch(dimK: Int,
                       maxIterations: Int = 1000,
                       tolerance: Double = 1e-9,
                       sketcher: TensorSketcher[Double, Double],
+                      randomisedSVD: Boolean = true,
                       nonNegativeDocumentConcentration: Boolean = true) extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
@@ -26,11 +27,18 @@ class TensorLDASketch(dimK: Int,
       dimK, alpha0,
       tolerance,
       documents_,
-      sketcher
+      sketcher,
+      randomisedSVD = randomisedSVD
     )
 
-    val myALS: ALSSketch = new ALSSketch(dimK, myDataSketch, sketcher)
-    myALS.run(documents.sparkContext, maxIterations)
+    val myALS: ALSSketch = new ALSSketch(
+      dimK,
+      myDataSketch,
+      sketcher,
+      nonNegativeDocumentConcentration = nonNegativeDocumentConcentration
+    )
+
+    myALS.run
   }
 
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -103,7 +103,7 @@ object DataCumulantSketch {
     val broadcasted_W = sc.broadcast(W)
     val broadcasted_sketcher = sc.broadcast(sketcher)
 
-    var fft_Ta: DenseMatrix[Complex] = validDocuments
+    val fft_Ta: DenseMatrix[Complex] = validDocuments
       .map {
         case (_, len, vec) => update_thirdOrderMoments(
           alpha0,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -38,7 +38,7 @@ class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Ze
          val B: Int = 1,
          val xi: Tensor[(Int, Int, Int), W],
          val h: Tensor[(Int, Int, Int), Int])
-  extends TensorSketcherBase[V, W] {
+  extends TensorSketcherBase[V, W] with Serializable {
 
   // order of the tensor
   val p: Int = n.size

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,0 +1,29 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.{*, Counter, DenseMatrix, Tensor, max, norm}
+import breeze.math.Complex
+
+
+object TensorOps {
+  def matrixNorm(m: DenseMatrix[Complex]): Double = {
+    max(norm(m(::, *)))
+  }
+
+  def unfoldTensor3d(t: Tensor[Seq[Int], Double], n: Seq[Int]): DenseMatrix[Double] = {
+    assert(n.length == 3)
+    val m = DenseMatrix.zeros[Double](n(0), n(1) * n(2))
+    for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
+      m(i, j * n(2) + k) = t(Seq(i, j, k))
+    }
+    m
+  }
+
+  def tensor3dFromUnfolded(g: DenseMatrix[Double], n: Seq[Int]): Tensor[Seq[Int], Double] = {
+    assert(n.length == 3)
+    val t: Tensor[Seq[Int], Double] = Counter()
+    for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
+      t(Seq(i, j, k)) = g(i, j * n(2) + k)
+    }
+    t
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -9,7 +9,7 @@ import scala.reflect.ClassTag
 
 object TensorOps {
   def matrixNorm(m: DenseMatrix[Complex]): Double = {
-    max(norm(m(::, *)))
+    norm(norm(m(::, *)).toDenseVector)
   }
 
   def unfoldTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
@@ -28,22 +28,6 @@ object TensorOps {
     val t: Tensor[Seq[Int], V] = Counter[Seq[Int], V]
     for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
       t(Seq(i, j, k)) = g(i, k * n(1) + j)
-    }
-    t
-  }
-
-  def makeRank1Tensor[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
-       (v: Seq[DenseVector[V]]): Tensor[Seq[Int], V] = {
-    val n: Seq[Int] = v map { _.length }
-    val t: Tensor[Seq[Int], V] = Counter[Seq[Int], V]
-
-    val multiIndexRange = cartesianProduct(n map { Range(0, _) })
-    for (i <- multiIndexRange) {
-      val l = for {
-        k <- n.indices
-      } yield v(k)(i(k))
-
-      t(i) = l.product
     }
     t
   }
@@ -67,11 +51,5 @@ object TensorOps {
       result(::, i) := krprod[V](A(::, i), B(::, i))
     }
     result
-  }
-
-  private def cartesianProduct[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] = {
-    xs.foldLeft(Seq(Seq.empty[A])){
-      (x, y) => for (a <- x.view; b <- y) yield a :+ b
-    }
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,7 +1,10 @@
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{*, Counter, DenseMatrix, Tensor, max, norm}
-import breeze.math.Complex
+import breeze.linalg.{*, Counter, DenseMatrix, DenseVector, Tensor, max, norm}
+import breeze.math.{Complex, Semiring}
+import breeze.storage.Zero
+
+import scala.reflect.ClassTag
 
 
 object TensorOps {
@@ -9,21 +12,66 @@ object TensorOps {
     max(norm(m(::, *)))
   }
 
-  def unfoldTensor3d(t: Tensor[Seq[Int], Double], n: Seq[Int]): DenseMatrix[Double] = {
+  def unfoldTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+        (t: Tensor[Seq[Int], V], n: Seq[Int]): DenseMatrix[V] = {
     assert(n.length == 3)
-    val m = DenseMatrix.zeros[Double](n(0), n(1) * n(2))
+    val m = DenseMatrix.zeros[V](n(0), n(1) * n(2))
     for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
-      m(i, j * n(2) + k) = t(Seq(i, j, k))
+      m(i, k * n(1) + j) = t(Seq(i, j, k))
     }
     m
   }
 
-  def tensor3dFromUnfolded(g: DenseMatrix[Double], n: Seq[Int]): Tensor[Seq[Int], Double] = {
+  def tensor3dFromUnfolded[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+      (g: DenseMatrix[V], n: Seq[Int]): Tensor[Seq[Int], V] = {
     assert(n.length == 3)
-    val t: Tensor[Seq[Int], Double] = Counter()
+    val t: Tensor[Seq[Int], V] = Counter[Seq[Int], V]
     for (i <- 0 until n(0); j <- 0 until n(1); k <- 0 until n(2)) {
-      t(Seq(i, j, k)) = g(i, j * n(2) + k)
+      t(Seq(i, j, k)) = g(i, k * n(1) + j)
     }
     t
+  }
+
+  def makeRank1Tensor[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+       (v: Seq[DenseVector[V]]): Tensor[Seq[Int], V] = {
+    val n: Seq[Int] = v map { _.length }
+    val t: Tensor[Seq[Int], V] = Counter[Seq[Int], V]
+
+    val multiIndexRange = cartesianProduct(n map { Range(0, _) })
+    for (i <- multiIndexRange) {
+      val l = for {
+        k <- n.indices
+      } yield v(k)(i(k))
+
+      t(i) = l.product
+    }
+    t
+  }
+
+  /** Khatri-Rao product */
+  def krprod[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+       (x: DenseVector[V], y: DenseVector[V]): DenseVector[V] = {
+    val ev = implicitly[Numeric[V]]
+    import ev._
+
+    val seq = for (i <- 0 until x.size; j <- 0 until y.size) yield x(i) * y(j)
+    DenseVector(seq: _*)
+  }
+
+  /** Khatri-Rao product */
+  def krprod[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+        (A: DenseMatrix[V], B: DenseMatrix[V]): DenseMatrix[V] = {
+    assert(A.cols == B.cols)
+    val result = DenseMatrix.zeros[V](A.rows * B.rows, A.cols)
+    for (i <- 0 until A.cols) {
+      result(::, i) := krprod[V](A(::, i), B(::, i))
+    }
+    result
+  }
+
+  private def cartesianProduct[A](xs: Traversable[Traversable[A]]): Seq[Seq[A]] = {
+    xs.foldLeft(Seq(Seq.empty[A])){
+      (x, y) => for (a <- x.view; b <- y) yield a :+ b
+    }
   }
 }

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketchTest.scala
@@ -1,0 +1,49 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+import breeze.linalg._
+import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.signal.fourierTr
+import breeze.math.Complex
+import breeze.numerics.abs
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.scalatest._
+import org.scalatest.Matchers._
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.utils.TensorOps
+import edu.uci.eecs.spectralLDA.testharness.Context
+
+class ALSSketchTest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  "T(C katri-rao dot B) via sketching" should "be close to the exact result" in {
+    val k: Int = 20
+    val p: DenseVector[Double] = DenseVector.rand(k)
+    val t: Tensor[Seq[Int], Double] = Counter()
+    for (i <- 0 until k; j <- 0 until k; l <- 0 until k) {
+      t(Seq(i, j, l)) = p(i) * p(j) * p(l)
+    }
+
+    val sketcher = TensorSketcher[Double, Double](
+      n = Seq(k, k, k),
+      B = 100,
+      b = Math.pow(2, 8).toInt
+    )
+
+    val sketch_t = sketcher.sketch(t)
+    val fft_sketch_t: DenseMatrix[Complex] = fourierTr(sketch_t(*, ::))
+
+    val C: DenseMatrix[Double] = DenseMatrix.rand(k, k)
+    val B: DenseMatrix[Double] = DenseMatrix.rand(k, k)
+    val krCB = TensorOps.krprod(C, B)
+
+    val exactResult = TensorOps.unfoldTensor3d(t, Seq(k, k, k)) * krCB
+    val sketchResult = TensorSketchOps.TIUV(fft_sketch_t, B, C, sketcher)
+
+    val diff = sketchResult - exactResult
+    val norm1 = norm(norm(exactResult(::, *)).toDenseVector)
+    val norm2 = norm(norm(diff(::, *)).toDenseVector)
+    norm2 should be <= norm1 * 0.2
+  }
+
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -1,0 +1,80 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+import breeze.linalg._
+import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.numerics.sqrt
+import breeze.signal.fourierTr
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.scalatest._
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
+
+class TensorLDASketchTest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+
+  /*
+  "Simulated LDA" should "be recovered" in {
+    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 5.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
+      Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.6, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.6))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 20,
+      numTokensPerDocument = 1000
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val sketcher = TensorSketcher[Double, Double](
+      n = Seq(3, 3, 3),
+      B = 10,
+      b = Math.pow(2, 2).toInt
+    )
+
+    val tensorLDA = new TensorLDASketch(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      sketcher = sketcher,
+      maxIterations = 50,
+      nonNegativeDocumentConcentration = false,
+      randomisedSVD = false
+    )
+
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)
+
+    info(fitted_beta.toString())
+    info(fitted_alpha.toString())
+  }
+*/
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -56,7 +56,7 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
     val sketcher = TensorSketcher[Double, Double](
       n = Seq(3, 3, 3),
       B = 100,
-      b = Math.pow(2, 7).toInt
+      b = Math.pow(2, 8).toInt
     )
 
     val tensorLDA = new TensorLDASketch(
@@ -74,7 +74,18 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
     // to the order of initial alpha and beta
     val i = argsort(fitted_alpha)
     val sorted_beta = fitted_beta(::, i).toDenseMatrix
+    // if one vector is all negative, multiply it by -1 to turn it positive
+    for (j <- 0 until sorted_beta.cols) {
+      if (max(sorted_beta(::, j)) <= 0.0) {
+        sorted_beta(::, j) :*= -1.0
+      }
+    }
     val sorted_alpha = fitted_alpha(i).toDenseVector
+
+    info(s"Expecting alpha: $alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+    info(s"Expecting beta:\n$allTokenDistributions")
+    info(s"Obtained beta:\n$sorted_beta")
 
     val diff_beta: DenseMatrix[Double] = sorted_beta - allTokenDistributions
     val diff_alpha: DenseVector[Double] = sorted_alpha - alpha

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -2,8 +2,6 @@ package edu.uci.eecs.spectralLDA.algorithm
 
 import breeze.linalg._
 import breeze.stats.distributions.{Dirichlet, Multinomial}
-import breeze.numerics.sqrt
-import breeze.signal.fourierTr
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 import org.scalatest._
 import org.scalatest.Matchers._
@@ -40,9 +38,8 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
     wordCounts
   }
 
-  /*
   "Simulated LDA" should "be recovered" in {
-    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 5.0, 5.0)
+    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 10.0, 20.0)
     val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
       Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
         0.1, 0.1, 0.6, 0.1, 0.1,
@@ -51,30 +48,41 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
     val documents = simulateLDAData(
       alpha,
       allTokenDistributions,
-      numDocuments = 20,
+      numDocuments = 2000,
       numTokensPerDocument = 1000
     )
     val documentsRDD = sc.parallelize(documents)
 
     val sketcher = TensorSketcher[Double, Double](
       n = Seq(3, 3, 3),
-      B = 10,
-      b = Math.pow(2, 2).toInt
+      B = 100,
+      b = Math.pow(2, 7).toInt
     )
 
     val tensorLDA = new TensorLDASketch(
       dimK = 3,
       alpha0 = sum(alpha),
       sketcher = sketcher,
-      maxIterations = 50,
+      maxIterations = 200,
       nonNegativeDocumentConcentration = false,
       randomisedSVD = false
     )
 
     val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)
 
-    info(fitted_beta.toString())
-    info(fitted_alpha.toString())
+    // Rearrange the elements/columns of fitted_alpha and fitted_beta
+    // to the order of initial alpha and beta
+    val i = argsort(fitted_alpha)
+    val sorted_beta = fitted_beta(::, i).toDenseMatrix
+    val sorted_alpha = fitted_alpha(i).toDenseVector
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - allTokenDistributions
+    val diff_alpha: DenseVector[Double] = sorted_alpha - alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    norm_diff_beta should be <= 0.2
+    norm_diff_alpha should be <= 4.0
   }
-*/
 }

--- a/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
@@ -1,0 +1,184 @@
+package edu.uci.eecs.spectralLDA.datamoments
+
+import breeze.linalg._
+import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.numerics.sqrt
+import breeze.signal.fourierTr
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import edu.uci.eecs.spectralLDA.utils.TensorOps
+import org.scalatest._
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
+
+class DataCumulantSketchTest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+
+  "Sketch of whitened M3" should "be correct" in {
+    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 10.0, 20.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
+      Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.6, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.6))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 2000,
+      numTokensPerDocument = 100
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val sketcher = TensorSketcher[Double, Double](
+      n = Seq(3, 3, 3),
+      B = 10,
+      b = Math.pow(2, 8).toInt
+    )
+
+    val cumulant = DataCumulantSketch.getDataCumulant(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documentsRDD,
+      sketcher,
+      randomisedSVD = false
+    )
+
+    val whitened_M3: Tensor[Seq[Int], Double] = expected_whitened_M3(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documents
+    )
+
+    val sketch_whitened_M3 = sketcher.sketch(whitened_M3)
+    val fft_sketch_whitened_M3 = fourierTr(sketch_whitened_M3(*, ::))
+
+    TensorOps.matrixNorm(cumulant.fftSketchWhitenedM3 - fft_sketch_whitened_M3) should be <= 1e-6
+  }
+
+  private def expected_whitened_M3(dimK: Int,
+                                   alpha0: Double,
+                                   documents: Seq[(Long, SparseVector[Double])])
+                                  (implicit tolerance: Double = 1e-9)
+  : Tensor[Seq[Int], Double] = {
+    val v = documents map { _._2.toDenseVector }
+    val numDocs = v.length
+    val V = v.head.length
+
+    // Compute unshifted M1, M2, M3
+    val M1: DenseVector[Double] = v
+      .map { x => x / sum(x) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val E_x1_x2: DenseMatrix[Double] = v
+      .map { x => (x * x.t - diag(x)) / (sum(x) * (sum(x) - 1)) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val seq_x1_x2_x3: Seq[DenseMatrix[Double]] = for {
+      c <- v
+      l = sum(c)
+
+      rawM3: DenseMatrix[Double] = DenseMatrix.zeros[Double](V, V * V)
+      fillM3 = for (i <- 0 until V; j <- 0 until V; k <- 0 until V) {
+        val j2 = j * V + k
+        rawM3(i, j2) = c(i) * c(j) * c(k)
+        if (i == j)
+          rawM3(i, j2) -= c(i) * c(k)
+        if (i == k)
+          rawM3(i, j2) -= c(i) * c(j)
+        if (j == k)
+          rawM3(i, j2) -= c(i) * c(j)
+        if (i == j && j == k)
+          rawM3(i, j2) += 2 * c(i)
+      }
+      m3 = rawM3 / (l * (l - 1) * (l - 2))
+    } yield m3
+
+    val E_x1_x2_x3 = seq_x1_x2_x3
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    // Compute shifted M2, M3
+    val (shiftedM2: DenseMatrix[Double], shiftedM3: DenseMatrix[Double]) = shiftMoments(M1, E_x1_x2, E_x1_x2_x3, alpha0)
+    val scaledShiftedM2 = shiftedM2 * (alpha0 + 1)
+    val scaledShiftedM3 = shiftedM3 * ((alpha0 + 1) * (alpha0 + 2) / 2.0)
+
+    // Eigendecomposition of shiftedM2
+    val eigSym.EigSym(sigma, u) = eigSym(scaledShiftedM2)
+    val i = argsort(sigma)
+    val (truncated_u: DenseMatrix[Double], truncated_sigma: DenseVector[Double]) = (
+      u(::, i.slice(V - dimK, V)).copy, sigma(i.slice(V - dimK, V)).copy)
+
+    // Whitening matrix
+    val W: DenseMatrix[Double] = truncated_u * diag(truncated_sigma map { x => 1 / (sqrt(x) + tolerance) })
+
+    // Whiten M3
+    val unfolded_whitenedM3: DenseMatrix[Double] = W.t * scaledShiftedM3 * kron(W.t, W.t).t
+
+    TensorOps.tensor3dFromUnfolded(unfolded_whitenedM3, Seq(dimK, dimK, dimK))
+  }
+
+
+  private def shiftMoments(M1: DenseVector[Double],
+                           M2: DenseMatrix[Double],
+                           M3: DenseMatrix[Double],
+                           alpha0: Double
+                          ): (DenseMatrix[Double], DenseMatrix[Double]) = {
+    val d: Int = M1.size
+    val kronM1: DenseMatrix[Double] = M1 * M1.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM2 = M2 - (alpha0 / (alpha0 + 1)) * kronM1
+
+    // We always unfold the 3rd-order tensors in matrix of size (d,d^2)
+    // G = E[x1 tensordot x2 tensordot M1] + E[x1 tensordot M1 tensordot x2]
+    // H = G + E[M1 tensordot x1 tensordot x2]
+    val G: Seq[DenseVector[Double]] = (0 until d) map { i =>
+      val kron = M1 * M2(i, ::)
+      (kron + kron.t).toDenseVector
+    }
+    val G2 = DenseMatrix.zeros[Double](d, d * M2.cols)
+    for (i <- 0 until d) {
+      G2(i, ::) := G(i).t
+    }
+    val H = G2 + M1 * M2.toDenseVector.t
+
+    // K = M1 tensordot M1 tensordot M1
+    val K = M1 * kronM1.toDenseVector.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM3 = M3 -
+      (alpha0 / (alpha0 + 2)) * H +
+      (2 * alpha0 * alpha0 / (alpha0 + 2) / (alpha0 + 1)) * K
+
+    (shiftedM2, shiftedM3)
+  }
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
@@ -108,7 +108,7 @@ class DataCumulantSketchTest extends FlatSpec with Matchers {
 
       rawM3: DenseMatrix[Double] = DenseMatrix.zeros[Double](V, V * V)
       fillM3 = for (i <- 0 until V; j <- 0 until V; k <- 0 until V) {
-        val j2 = j * V + k
+        val j2 = k * V + j
         rawM3(i, j2) = c(i) * c(j) * c(k)
         if (i == j)
           rawM3(i, j2) -= c(i) * c(k)

--- a/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
@@ -51,7 +51,7 @@ class DataCumulantSketchTest extends FlatSpec with Matchers {
     val documents = simulateLDAData(
       alpha,
       allTokenDistributions,
-      numDocuments = 2000,
+      numDocuments = 100,
       numTokensPerDocument = 100
     )
     val documentsRDD = sc.parallelize(documents)

--- a/src/test/scala/edu/uci/eecs/spectralLDA/testharness/Context.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/testharness/Context.scala
@@ -1,0 +1,14 @@
+package edu.uci.eecs.spectralLDA.testharness
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+object Context {
+  private val conf : SparkConf = new SparkConf()
+    .setMaster("local[2]")
+    .setAppName("TensorLDASketchTest")
+  private val sc: SparkContext = new SparkContext(conf)
+
+  def getSparkContext: SparkContext = {
+    sc
+  }
+}


### PR DESCRIPTION
Add the class `TensorLDASketch` for the Spectral LDA via sketching and all the related tests. Sample usage of `TensorLDASketch`:

```
val tensorLDA = new TensorLDASketch(
      dimK = 3,
      alpha0 = sum(alpha),
      sketcher = sketcher,
      maxIterations = 200
    )

val (beta: DenseMatrix[Double], alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)

```

Implemented:

1. `DataCumulantSketch` which now does sketching of whitened M3 (The ref paper v2 has a typo in Eq (26)).
2. `ALSSketch` for the ALS algorithm via sketching for the CP Decomposition
3. `TensorLDASketch` which calls behind the scene `DataCumulantSketch` and `ALSSketch`.  

TODO:

1. For higher performance, Spark should be compiled with native BLAS/FFT support. I'll have a look.
2. At the test phase, occasionally it'll throw an error performing FFT, just relaunch it: `sbt "+ test"`

Ref:
Fast and Guaranteed Tensor Decomposition via Sketching
http://arxiv.org/abs/1506.04448


  