### PR TITLE
Refactoring to unify the code hierarchy, and run on large data sets

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -100,7 +100,7 @@ object SpectralLDA {
 
     println("Start reading data...")
     val (documents: RDD[(Long, SparseVector[Double])], vocabArray: Array[String]) = if (params.libsvm == 1) {
-      TextProcessor.processDocuments_libsvm(sc, params.input, params.vocabSize)
+      TextProcessor.processDocuments_libsvm(sc, params.input.mkString(","), params.vocabSize)
     }
     else {
       TextProcessor.processDocuments(sc, params.input.mkString(","), params.stopWordFile, params.vocabSize)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -103,7 +103,7 @@ object SpectralLDA {
       TextProcessor.processDocuments_libsvm(sc, params.input, params.vocabSize)
     }
     else {
-      TextProcessor.processDocuments(sc, params.input, params.stopWordFile, params.vocabSize)
+      TextProcessor.processDocuments(sc, params.input.mkString(","), params.stopWordFile, params.vocabSize)
     }
     println("Finished reading data.")
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -13,6 +13,7 @@
  import scalaxy.loops._
  import scala.language.postfixOps
  import scala.util.control.Breaks._
+ import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
 
 class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
 
@@ -66,7 +67,7 @@ class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
     val whitenedTopicWordMatrix: DenseMatrix[Double] = unwhiteningMatrix * A.copy
     val alpha: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
     val topicWordMatrix: breeze.linalg.DenseMatrix[Double] = whitenedTopicWordMatrix * breeze.linalg.diag(lambda)
-    val topicWordMatrix_normed: breeze.linalg.DenseMatrix[Double] = simplexProj_Matrix(topicWordMatrix)
+    val topicWordMatrix_normed: DenseMatrix[Double] = NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix)
     (topicWordMatrix_normed, alpha)
   }
 
@@ -88,48 +89,4 @@ class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
     val rhs: DenseVector[Double] = AlgebraUtil.Multip_KhatrioRao(T, C_old, B_old)
     Inverted * rhs
   }
-
-  private def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
-    val M_onSimplex: DenseMatrix[Double] = DenseMatrix.zeros[Double](M.rows, M.cols)
-    for(i <- 0 until M.cols optimized){
-      val thisColumn = M(::,i)
-
-      val tmp1 = simplexProj(thisColumn)
-      val tmp2 = simplexProj(-thisColumn)
-      val err1:Double = breeze.linalg.norm(tmp1 - thisColumn)
-      val err2:Double = breeze.linalg.norm(tmp2 - thisColumn)
-      if(err1 > err2){
-        M_onSimplex(::,i) := tmp2
-      }
-      else{
-        M_onSimplex(::,i) := tmp1
-      }
-    }
-    M_onSimplex
-  }
-
-  private def simplexProj(V: DenseVector[Double]): DenseVector[Double]={
-    // val z:Double = 1.0
-    val len: Int = V.length
-    val U: DenseVector[Double] = DenseVector(V.copy.toArray.sortWith(_ > _))
-    val cums: DenseVector[Double] = DenseVector(AlgebraUtil.Cumsum(U.toArray).map(x => x-1))
-    val Index: DenseVector[Double] = DenseVector((1 to (len + 1)).toArray.map(x => 1.0/x.toDouble))
-    val InterVec: DenseVector[Double] = cums :* Index
-    val TobefindMax: DenseVector[Double] = U - InterVec
-    var maxIndex : Int = 0
-    // find maxIndex
-    breakable{
-      for (i <- 0 until len optimized){
-        if (TobefindMax(len - i - 1) > 0){
-          maxIndex = len - i - 1
-          break()
-        }
-      }
-    }
-    val theta: Double = InterVec(maxIndex)
-    val W: DenseVector[Double] = V.map(x => x - theta)
-    val P_norm: DenseVector[Double] = W.map(x => if (x > 0) x else 0)
-    P_norm
-  }
-
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -8,8 +8,10 @@
  import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
  import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
  import breeze.linalg.{DenseMatrix, DenseVector}
+ import breeze.stats.distributions.{Rand, RandBasis}
  import org.apache.spark.rdd.RDD
  import org.apache.spark.SparkContext
+
  import scalaxy.loops._
  import scala.language.postfixOps
  import scala.util.control.Breaks._
@@ -17,17 +19,15 @@
 
 class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
 
-  def run(sc:SparkContext, maxIterations: Int): (DenseMatrix[Double], DenseVector[Double])={
+  def run(sc:SparkContext, maxIterations: Int)
+         (implicit randBasis: RandBasis = Rand)
+     : (DenseMatrix[Double], DenseVector[Double])={
     val T: breeze.linalg.DenseMatrix[Double] = myData.thirdOrderMoments
     val unwhiteningMatrix: DenseMatrix[Double] = myData.unwhiteningMatrix
 
-    val SEED_A: Long = System.currentTimeMillis
-    val SEED_B: Long = System.currentTimeMillis
-    val SEED_C: Long = System.currentTimeMillis
-
-    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_A)
-    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_B)
-    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_C)
+    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
 
     var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
     var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -9,6 +9,7 @@ import edu.uci.eecs.spectralLDA.datamoments.DataCumulantSketch
 import breeze.linalg.{*, DenseMatrix, DenseVector, diag}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
+import breeze.stats.distributions.{Rand, RandBasis}
 import breeze.stats.median
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
@@ -25,14 +26,11 @@ class ALSSketch(dimK: Int,
   val fft_sketch_T: DenseMatrix[Complex] = myDataSketch.fftSketchWhitenedM3
   val unwhiteningMatrix: DenseMatrix[Double] = myDataSketch.unwhiteningMatrix
 
-  def run: (DenseMatrix[Double], DenseVector[Double]) = {
-    val SEED_A: Long = System.currentTimeMillis
-    val SEED_B: Long = System.currentTimeMillis
-    val SEED_C: Long = System.currentTimeMillis
-
-    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_A)
-    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_B)
-    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK, SEED_C)
+  def run(implicit randBasis: RandBasis = Rand)
+        : (DenseMatrix[Double], DenseVector[Double]) = {
+    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
 
     var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
     var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -7,14 +7,17 @@ package edu.uci.eecs.spectralLDA.algorithm
  */
 import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
 import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, sum}
+import breeze.stats.distributions.{Rand, RandBasis}
 import org.apache.spark.rdd.RDD
 
 class TensorLDA(dimK: Int,
                 alpha0: Double,
                 maxIterations: Int = 1000,
-                tolerance: Double = 1e-9) extends Serializable {
+                tolerance: Double = 1e-9)
+                extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
+         (implicit randBasis: RandBasis = Rand)
           : (DenseMatrix[Double], DenseVector[Double]) = {
     val documents_ = documents map {
       case (id, wc) => (id, sum(wc), wc)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -6,6 +6,7 @@ package edu.uci.eecs.spectralLDA.algorithm
   */
 import edu.uci.eecs.spectralLDA.datamoments.{DataCumulant, DataCumulantSketch}
 import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, sum}
+import breeze.stats.distributions.{Rand, RandBasis}
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 import org.apache.spark.rdd.RDD
 
@@ -19,6 +20,7 @@ class TensorLDASketch(dimK: Int,
   extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
+         (implicit randBasis: RandBasis = Rand)
   : (DenseMatrix[Double], DenseVector[Double]) = {
     val myDataSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
       dimK, alpha0,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -4,10 +4,11 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Tensor Decomposition Algorithms.
   * Alternating Least Square algorithm is implemented.
   */
-import edu.uci.eecs.spectralLDA.datamoments.{DataCumulant, DataCumulantSketch}
-import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, sum}
+import edu.uci.eecs.spectralLDA.datamoments.DataCumulantSketch
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, diag}
 import breeze.stats.distributions.{Rand, RandBasis}
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
 import org.apache.spark.rdd.RDD
 
 class TensorLDASketch(dimK: Int,
@@ -22,7 +23,7 @@ class TensorLDASketch(dimK: Int,
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)
   : (DenseMatrix[Double], DenseVector[Double]) = {
-    val myDataSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
+    val cumulantSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
       dimK, alpha0,
       documents,
       sketcher,
@@ -31,13 +32,24 @@ class TensorLDASketch(dimK: Int,
 
     val myALS: ALSSketch = new ALSSketch(
       dimK,
-      myDataSketch,
+      cumulantSketch.fftSketchWhitenedM3,
       sketcher,
-      nonNegativeDocumentConcentration = nonNegativeDocumentConcentration
+      maxIterations = maxIterations
     )
 
-    val (beta, alpha) = myALS.run
-    (beta, alpha * alpha0)
-  }
+    val (nu: DenseMatrix[Double], lambda: DenseVector[Double]) = myALS.run
 
+    // unwhiten the results
+    val alpha: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2)) * alpha0
+    val topicWordMatrix: breeze.linalg.DenseMatrix[Double] = cumulantSketch.unwhiteningMatrix * nu * diag(lambda)
+
+    // non-negativity adjustment for the word distributions per topic
+    if (nonNegativeDocumentConcentration) {
+      val topicWordMatrix_normed = NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix)
+      (topicWordMatrix_normed, alpha)
+    }
+    else {
+      (topicWordMatrix, alpha)
+    }
+  }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -7,11 +7,12 @@ package edu.uci.eecs.spectralLDA.datamoments
 
 import edu.uci.eecs.spectralLDA.utils.RandNLA
 import breeze.linalg._
+import breeze.stats.distributions.{Rand, RandBasis}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
-import scala.collection.mutable
 
+import scala.collection.mutable
 import scalaxy.loops._
 import scala.language.postfixOps
 
@@ -24,6 +25,7 @@ object DataCumulant {
                       alpha0: Double,
                       tolerance: Double,
                       documents: RDD[(Long, Double, SparseVector[Double])])
+                     (implicit randBasis: RandBasis = Rand)
         : DataCumulant = {
     val sc: SparkContext = documents.sparkContext
     val dimVocab = documents.take(1)(0)._3.length

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -40,7 +40,7 @@ object DataCumulant {
     println("Finished calculating first order moments.")
 
     println("Start calculating second order moments...")
-    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = RandNLA.whiten(sc, alpha0,
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = RandNLA.whiten2(sc, alpha0,
       dimVocab, dimK, numDocs, firstOrderMoments, documents)
     println("Finished calculating second order moments and whitening matrix.")
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -89,7 +89,7 @@ object DataCumulant {
     }
     println("Finished calculating third order moments.")
     val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
-    (Ta / numDocs.toDouble - Ta_shift, unwhiteningMatrix)
+    (Ta / numDocs.toDouble + Ta_shift, unwhiteningMatrix)
   }
 
   private def whiten(sc: SparkContext,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -37,23 +37,6 @@ object DataCumulant {
     val firstOrderMoments: DenseVector[Double] = M1 / numDocs.toDouble
     println("Finished calculating first order moments.")
 
-    val (thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double]) = computeThirdOrderMoments(
-      sc, alpha0, dimVocab, dimK,
-      numDocs, firstOrderMoments, documents,
-      tolerance
-    )
-
-    new DataCumulant(thirdOrderMoments, unwhiteningMatrix)
-  }
-
-  private def computeThirdOrderMoments(sc: SparkContext,
-                                       alpha0: Double,
-                                       dimVocab: Int, dimK: Int,
-                                       numDocs: Long,
-                                       firstOrderMoments: DenseVector[Double],
-                                       documents: RDD[(Long, Double, SparseVector[Double])],
-                                       tolerance: Double)
-  : (DenseMatrix[Double], DenseMatrix[Double]) = {
     println("Start calculating second order moments...")
     val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = whiten(sc, alpha0,
       dimVocab, dimK, numDocs, firstOrderMoments, documents)
@@ -83,13 +66,16 @@ object DataCumulant {
       for (id_j <- 0 until dimK optimized) {
         for (id_l <- 0 until dimK optimized) {
           Ta_shift(id_i, id_j * dimK + id_l) += (alpha0sq * firstOrderMoments_whitened(id_i)
-              * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l))
+            * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l))
         }
       }
     }
     println("Finished calculating third order moments.")
+
+    val thirdOrderMoments = Ta / numDocs.toDouble + Ta_shift
     val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
-    (Ta / numDocs.toDouble + Ta_shift, unwhiteningMatrix)
+
+    new DataCumulant(thirdOrderMoments, unwhiteningMatrix)
   }
 
   private def whiten(sc: SparkContext,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -102,9 +102,9 @@ object DataCumulantSketch {
     val broadcasted_W = sc.broadcast(W)
     val broadcasted_sketcher = sc.broadcast(sketcher)
 
-    val fft_Ta: DenseMatrix[Complex] = validDocuments
+    val fft_Ta1: DenseMatrix[Complex] = validDocuments
       .flatMap {
-        case (_, len, vec) => tensorProdTerms(
+        case (_, len, vec) => whitenedM3FirstOrderTerms(
           alpha0,
           broadcasted_W.value,
           firstOrderMoments_whitened,
@@ -120,8 +120,45 @@ object DataCumulantSketch {
       .reduce(_ + _)
       .map(_ / numDocs.toDouble)
 
-    broadcasted_W.unpersist()
-    broadcasted_sketcher.unpersist()
+    val fft_Ta2: DenseMatrix[Complex] = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3SecondOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, x: DenseVector[Double]) => fft_sketch2(
+          i, x,
+          broadcasted_W.value,
+          broadcasted_sketcher.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    val fft_Ta3: DenseMatrix[Complex] = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3ThirdOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, p: Double) => fft_sketch3(
+          i, p,
+          broadcasted_W.value,
+          broadcasted_sketcher.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
 
     // sketch of q=W^T M1
     val fft_sketch_q_otimes_3 = fft_sketch(
@@ -130,8 +167,11 @@ object DataCumulantSketch {
       sketcher
     )
 
+    broadcasted_W.unpersist()
+    broadcasted_sketcher.unpersist()
+
     // sketch of whitened M3
-    val fft_sketch_whitened_M3: DenseMatrix[Complex] = fft_Ta + fft_sketch_q_otimes_3
+    val fft_sketch_whitened_M3: DenseMatrix[Complex] = fft_Ta1 + fft_Ta2 + fft_Ta3 + fft_sketch_q_otimes_3
 
     println("Finished calculating third order moments.")
 
@@ -141,33 +181,32 @@ object DataCumulantSketch {
   }
 
 
-
   /** Compute the terms in the contribution of the document to the FFT of the sketch of whitened M3
     *
     * @param alpha0 Topic concentration
-    * @param W Whitening matrix $W\in\mathsf{R^{V\times k}$, where $V$ is the vocabulary size,
-    *          $k$ is the reduced dimension, $k<V$
-    * @param q Whitened M1, i.e. $W^T M1$
-    * @param n Word count vector for the current document
-    * @param len Total word counts for the current document
+    * @param W      Whitening matrix $W\in\mathsf{R^{V\times k}$, where $V$ is the vocabulary size,
+    *               $k$ is the reduced dimension, $k<V$
+    * @param q      Whitened M1, i.e. $W^T M1$
+    * @param n      Word count vector for the current document
+    * @param len    Total word counts for the current document
     * @return Sequence of the terms in the contribution of the document to the FFT of the sketch of whitened M3
     *         i.e. $E[x_1\otimes x_2\otimes x_3](W^T,W^T,W^T)-
-    *                  \frac{\alpha_0}{\alpha_0+2}\left(E[x_1\otimes x_2\otimes M1]
-    *                                       +E[x_1\otimes M1\otimes x_2]
-    *                                       +E[M1\otimes x_1\otimes x_2]\right)(W^T,W^T,W^T)$
+    *         \frac{\alpha_0}{\alpha_0+2}\left(E[x_1\otimes x_2\otimes M1]
+    *         +E[x_1\otimes M1\otimes x_2]
+    *         +E[M1\otimes x_1\otimes x_2]\right)(W^T,W^T,W^T)$
     *         Refer to Eq (22) in [Wang2015]
     *
-    * REFERENCES
-    * [Wang2015] Wang Y et al, Fast and Guaranteed Tensor Decomposition via Sketching, 2015,
-    *            http://arxiv.org/abs/1506.04448
+    *         REFERENCES
+    *         [Wang2015] Wang Y et al, Fast and Guaranteed Tensor Decomposition via Sketching, 2015,
+    *         http://arxiv.org/abs/1506.04448
     *
     */
-  private def tensorProdTerms(alpha0: Double,
-                              W: DenseMatrix[Double],
-                              q: DenseVector[Double],
-                              n: SparseVector[Double],
-                              len: Double)
-       : Seq[(Double, Seq[DenseVector[Double]])] = {
+  private def whitenedM3FirstOrderTerms(alpha0: Double,
+                                        W: DenseMatrix[Double],
+                                        q: DenseVector[Double],
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : Seq[(Double, Seq[DenseVector[Double]])] = {
     // $p=W^T n$, where n is the original word count vector
     val p: DenseVector[Double] = W.t * n
 
@@ -177,37 +216,107 @@ object DataCumulantSketch {
 
     var seqTerms = Seq[(Double, Seq[DenseVector[Double]])](
       (coeff1, Seq(p, p, p)),
-      (- coeff2 * h1, Seq(p, p, q)),
-      (- coeff2 * h1, Seq(p, q, p)),
-      (- coeff2 * h1, Seq(q, p, p))
+      (-coeff2 * h1, Seq(p, p, q)),
+      (-coeff2 * h1, Seq(p, q, p)),
+      (-coeff2 * h1, Seq(q, p, p))
     )
+    seqTerms
+  }
 
+  private def whitenedM3SecondOrderTerms(alpha0: Double,
+                                         W: DenseMatrix[Double],
+                                         q: DenseVector[Double],
+                                         n: SparseVector[Double],
+                                         len: Double)
+  : Seq[(Int, DenseVector[Double])] = {
+    val p: DenseVector[Double] = W.t * n
+
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    var seqTerms = Seq[(Int, DenseVector[Double])]()
     for ((wc_index, wc_value) <- n.activeIterator) {
-      val w: DenseVector[Double] = W(wc_index, ::).t
       seqTerms ++= Seq(
-        (- coeff1 * wc_value, Seq(w, w, p)),
-        (- coeff1 * wc_value, Seq(w, p, w)),
-        (- coeff1 * wc_value, Seq(p, w, w)),
-        (2 * coeff1 * wc_value, Seq(w, w, w)),
-        (coeff2 * h1 * wc_value, Seq(w, w, q)),
-        (coeff2 * h1 * wc_value, Seq(w, q, w)),
-        (coeff2 * h1 * wc_value, Seq(q, w, w))
+        (wc_index, -coeff1 * wc_value * p),
+        (wc_index, coeff2 * h1 * wc_value * q)
       )
     }
 
     seqTerms
   }
 
+  private def whitenedM3ThirdOrderTerms(alpha0: Double,
+                                        W: DenseMatrix[Double],
+                                        q: DenseVector[Double],
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : Seq[(Int, Double)] = {
+    val p: DenseVector[Double] = W.t * n
+
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    var seqTerms = Seq[(Int, Double)]()
+    for ((wc_index, wc_value) <- n.activeIterator) {
+      seqTerms :+= (wc_index, 2 * coeff1 * wc_value)
+    }
+
+    seqTerms
+  }
+
+
   private def fft_sketch(a: Double, b: Seq[DenseVector[Double]],
                          sketcher: TensorSketcher[Double, Double])
-       : DenseMatrix[Complex] = {
+  : DenseMatrix[Complex] = {
     val m: DenseMatrix[Complex] = (0 until 3)
       .map { (d) =>
         val sketch: DenseMatrix[Double] = sketcher.sketch(b(d), d)
         fourierTr(sketch(*, ::))
       }
-      .reduce (_ :* _)
+      .reduce(_ :* _)
 
     m * Complex(a, 0.0)
+  }
+
+  private def fft_sketch2(i: Int,
+                          x: DenseVector[Double],
+                          W: DenseMatrix[Double],
+                          sketcher: TensorSketcher[Double, Double])
+  : DenseMatrix[Complex] = {
+    val w: DenseVector[Double] = W(i, ::).t
+    val fft_sketch_w: Seq[DenseMatrix[Complex]] = (0 until 3)
+      .map { (d) =>
+        val sketch: DenseMatrix[Double] = sketcher.sketch(w, d)
+        fourierTr(sketch(*, ::))
+      }
+    val fft_sketch_x: Seq[DenseMatrix[Complex]] = (0 until 3)
+      .map { (d) =>
+        val sketch: DenseMatrix[Double] = sketcher.sketch(x, d)
+        fourierTr(sketch(*, ::))
+      }
+
+    val prod1 = fft_sketch_w(0) :* fft_sketch_w(1) :* fft_sketch_x(2)
+    val prod2 = fft_sketch_w(0) :* fft_sketch_x(1) :* fft_sketch_w(2)
+    val prod3 = fft_sketch_x(0) :* fft_sketch_w(1) :* fft_sketch_w(2)
+
+    prod1 + prod2 + prod3
+  }
+
+  private def fft_sketch3(i: Int,
+                          p: Double,
+                          W: DenseMatrix[Double],
+                          sketcher: TensorSketcher[Double, Double])
+  : DenseMatrix[Complex] = {
+    val w: DenseVector[Double] = W(i, ::).t
+    val z: DenseMatrix[Complex] = (0 until 3)
+      .map { (d) =>
+        val sketch: DenseMatrix[Double] = sketcher.sketch(w, d)
+        fourierTr(sketch(*, ::))
+      }
+      .reduce(_ :* _)
+
+    z * Complex(p, 0.0)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -4,7 +4,7 @@ package edu.uci.eecs.spectralLDA.datamoments
   * Data Cumulants Calculation.
   */
 
-import edu.uci.eecs.spectralLDA.utils.RandNLA
+import edu.uci.eecs.spectralLDA.utils.{RandNLA, TensorOps}
 import breeze.linalg._
 import breeze.math.Complex
 import breeze.numerics.sqrt
@@ -72,7 +72,7 @@ object DataCumulantSketch {
     println("Start calculating second order moments...")
     val E_x1_x2: DenseMatrix[Double] = validDocuments
       .map { case (_, len, vec) =>
-        (vec * vec.t - diag(vec)) / (len * (len - 1))
+        (TensorOps.spVectorTensorProd2d(vec) - diag(vec)) / (len * (len - 1))
       }
       .reduce(_ + _)
       .map(_ / numDocs.toDouble).toDenseMatrix

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -103,13 +103,19 @@ object DataCumulantSketch {
     val broadcasted_sketcher = sc.broadcast(sketcher)
 
     val fft_Ta: DenseMatrix[Complex] = validDocuments
-      .map {
-        case (_, len, vec) => update_thirdOrderMoments(
+      .flatMap {
+        case (_, len, vec) => tensorProdTerms(
           alpha0,
           broadcasted_W.value,
           firstOrderMoments_whitened,
-          vec, len,
-          broadcasted_sketcher.value)
+          vec, len
+        )
+      }
+      .map {
+        case (a: Double, b: Seq[DenseVector[Double]]) => fft_sketch(
+          a, b,
+          broadcasted_sketcher.value
+        )
       }
       .reduce(_ + _)
       .map(_ / numDocs.toDouble)
@@ -118,17 +124,15 @@ object DataCumulantSketch {
     broadcasted_sketcher.unpersist()
 
     // sketch of q=W^T M1
-    val fft_sketch_q: Seq[DenseMatrix[Complex]] = (0 until 3)
-      .map { (d) =>
-        val sketch: DenseMatrix[Double] = sketcher.sketch(firstOrderMoments_whitened, d)
-        fourierTr(sketch(*, ::))
-      }
-    val fft_sketch_q_otimes_3 = fft_sketch_q(0) :* fft_sketch_q(1) :* fft_sketch_q(2)
+    val fft_sketch_q_otimes_3 = fft_sketch(
+      2 * alpha0 * alpha0 / ((alpha0 + 1) * (alpha0 + 2)),
+      Seq(firstOrderMoments_whitened, firstOrderMoments_whitened, firstOrderMoments_whitened),
+      sketcher
+    )
 
     // sketch of whitened M3
-    val fft_sketch_whitened_M3: DenseMatrix[Complex] = (fft_Ta
-      + fft_sketch_q_otimes_3 * Complex(2 * alpha0 * alpha0 / ((alpha0 + 1) * (alpha0 + 2)), 0)
-      )
+    val fft_sketch_whitened_M3: DenseMatrix[Complex] = fft_Ta + fft_sketch_q_otimes_3
+
     println("Finished calculating third order moments.")
 
     val unwhiteningMatrix = eigenVectors * diag(sqrt(eigenValues))
@@ -137,7 +141,8 @@ object DataCumulantSketch {
   }
 
 
-  /** Compute the contribution of the document to the FFT of the sketch of whitened M3
+
+  /** Compute the terms in the contribution of the document to the FFT of the sketch of whitened M3
     *
     * @param alpha0 Topic concentration
     * @param W Whitening matrix $W\in\mathsf{R^{V\times k}$, where $V$ is the vocabulary size,
@@ -145,8 +150,7 @@ object DataCumulantSketch {
     * @param q Whitened M1, i.e. $W^T M1$
     * @param n Word count vector for the current document
     * @param len Total word counts for the current document
-    * @param sketcher The sketching facility
-    * @return The contribution of the document to the FFT of the sketch of whitened M3
+    * @return Sequence of the terms in the contribution of the document to the FFT of the sketch of whitened M3
     *         i.e. $E[x_1\otimes x_2\otimes x_3](W^T,W^T,W^T)-
     *                  \frac{\alpha_0}{\alpha_0+2}\left(E[x_1\otimes x_2\otimes M1]
     *                                       +E[x_1\otimes M1\otimes x_2]
@@ -158,99 +162,52 @@ object DataCumulantSketch {
     *            http://arxiv.org/abs/1506.04448
     *
     */
-  private def update_thirdOrderMoments(alpha0: Double,
-                                       W: DenseMatrix[Double],
-                                       q: DenseVector[Double],
-                                       n: SparseVector[Double],
-                                       len: Double,
-                                       sketcher: TensorSketcher[Double, Double])
-        : DenseMatrix[Complex] = {
-    /* ------------------------------------- */
-
+  private def tensorProdTerms(alpha0: Double,
+                              W: DenseMatrix[Double],
+                              q: DenseVector[Double],
+                              n: SparseVector[Double],
+                              len: Double)
+       : Seq[(Double, Seq[DenseVector[Double]])] = {
     // $p=W^T n$, where n is the original word count vector
     val p: DenseVector[Double] = W.t * n
 
-    // fft of sketch_p, $p=W^T n$, where $n$ is the original word count vector
-    val fft_sketch_p: Seq[DenseMatrix[Complex]] = (0 until 3)
-      .map { (d) =>
-        val sketch: DenseMatrix[Double] = sketcher.sketch(p, d)
-        fourierTr(sketch(*, ::))
-      }
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
 
-    // fft of sketch_q, $q=W^T M1$
-    val fft_sketch_q: Seq[DenseMatrix[Complex]] = (0 until 3)
-      .map { (d) =>
-        val sketch: DenseMatrix[Double] = sketcher.sketch(q, d)
-        fourierTr(sketch(*, ::))
-      }
-
-    /* ------------------------------------- */
-
-    // sketch of $p^{\otimes 3}$
-    val fft_sketch_p_otimes_3 = fft_sketch_p(0) :* fft_sketch_p(1) :* fft_sketch_p(2)
-
-    // sketch of $p\otimes p\otimes q$
-    val fft_sketch_p_p_q = fft_sketch_p(0) :* fft_sketch_p(1) :* fft_sketch_q(2)
-
-    // sketch of $p\otimes q\otimes p$
-    val fft_sketch_p_q_p = fft_sketch_p(0) :* fft_sketch_q(1) :* fft_sketch_p(2)
-
-    // sketch of $q\otimes p\otimes p$
-    val fft_sketch_q_p_p = fft_sketch_q(0) :* fft_sketch_p(1) :* fft_sketch_p(2)
-
-    /* ------------------------------------- */
-
-    // fft of sketch of $\sum_{i=1}^V -n_i\left(w_i\otimes w_i\otimes p+w_i\otimes p\otimes w_i
-    //                                           +p\otimes w_i\otimes w_i\right)
-    //                +\sum_{i=1}^V 2n_i w_i^{\otimes 3}$
-    // ref: Eq (25) in [Wang2015]
-    val fft_sum1: DenseMatrix[Complex] = fft_sketch_q(0) * Complex(0, 0)
-
-    // fft of sketch of $\sum_{i=1}^V -n_i\left(w_i\otimes w_i\otimes q
-    //                                          +w_i\otimes q\otimes w_i
-    //                                          +q\otimes w_i\otimes w_i\right)$
-    // ref: Eq (26) in [Wang2015]
-    val fft_sum2: DenseMatrix[Complex] = fft_sketch_q(0) * Complex(0, 0)
+    var seqTerms = Seq[(Double, Seq[DenseVector[Double]])](
+      (coeff1, Seq(p, p, p)),
+      (- coeff2 * h1, Seq(p, p, q)),
+      (- coeff2 * h1, Seq(p, q, p)),
+      (- coeff2 * h1, Seq(q, p, p))
+    )
 
     for ((wc_index, wc_value) <- n.activeIterator) {
-      val fft_sketch_w_i: Seq[DenseMatrix[Complex]] = (0 until 3)
-        .map { (d) =>
-          val sketch: DenseMatrix[Double] = sketcher.sketch(W(wc_index, ::).t, d)
-          fourierTr(sketch(*, ::))
-        }
-
-      // fft of sketch of $w_i^{\otimes 3}$
-      val fft_sketch_w_i_otimes_3 = fft_sketch_w_i(0) :* fft_sketch_w_i(1) :* fft_sketch_w_i(2)
-
-      // fft of sketch of $w_i\otimes w_i\otimes p
-      val fft_sketch_w_i_w_i_p = fft_sketch_w_i(0) :* fft_sketch_w_i(1) :* fft_sketch_p(2)
-      // fft of sketch of $w_i\otimes p\otimes w_i
-      val fft_sketch_w_i_p_w_i = fft_sketch_w_i(0) :* fft_sketch_p(1) :* fft_sketch_w_i(2)
-      // sketch of $p\otimes w_i\otimes w_i$
-      val fft_sketch_p_w_i_w_i = fft_sketch_p(0) :* fft_sketch_w_i(1) :* fft_sketch_w_i(2)
-
-      // sketch of $w_i\otimes w_i\otimes q
-      val fft_sketch_w_i_w_i_q = fft_sketch_w_i(0) :* fft_sketch_w_i(1) :* fft_sketch_q(2)
-      // sketch of $w_i\otimes q\otimes w_i
-      val fft_sketch_w_i_q_w_i = fft_sketch_w_i(0) :* fft_sketch_q(1) :* fft_sketch_w_i(2)
-      // sketch of $q\otimes w_i\otimes w_i$
-      val fft_sketch_q_w_i_w_i = fft_sketch_q(0) :* fft_sketch_w_i(1) :* fft_sketch_w_i(2)
-
-      fft_sum1 :+= - (fft_sketch_w_i_w_i_p + fft_sketch_w_i_p_w_i + fft_sketch_p_w_i_w_i) * Complex(wc_value, 0)
-      fft_sum1 :+= fft_sketch_w_i_otimes_3 * Complex(2 * wc_value, 0)
-
-      fft_sum2 :+= - (fft_sketch_w_i_w_i_q + fft_sketch_w_i_q_w_i + fft_sketch_q_w_i_w_i) * Complex(wc_value, 0)
+      val w: DenseVector[Double] = W(wc_index, ::).t
+      seqTerms ++= Seq(
+        (- coeff1 * wc_value, Seq(w, w, p)),
+        (- coeff1 * wc_value, Seq(w, p, w)),
+        (- coeff1 * wc_value, Seq(p, w, w)),
+        (2 * coeff1 * wc_value, Seq(w, w, w)),
+        (coeff2 * h1 * wc_value, Seq(w, w, q)),
+        (coeff2 * h1 * wc_value, Seq(w, q, w)),
+        (coeff2 * h1 * wc_value, Seq(q, w, w))
+      )
     }
 
-    // sketch of contribution to $E[x_1\otimes x_2\otimes x_3](W^T,W^T,W^T)$
-    val fft_sketch_contribution1 = (fft_sketch_p_otimes_3 + fft_sum1) / Complex(len * (len - 1) * (len - 2), 0)
+    seqTerms
+  }
 
-    // sketch of contribution to $\left(E[x_1\otimes x_2\otimes M1]
-    //                                  +E[x_1\otimes M1\otimes x_2]
-    //                                  +E[M1\otimes x_1\otimes x_2]\right)(W^T,W^T,W^T)$
-    val fft_sketch_contribution2 = ((fft_sketch_p_p_q + fft_sketch_p_q_p + fft_sketch_q_p_p + fft_sum2)
-      / Complex(len * (len - 1), 0))
+  private def fft_sketch(a: Double, b: Seq[DenseVector[Double]],
+                         sketcher: TensorSketcher[Double, Double])
+       : DenseMatrix[Complex] = {
+    val m: DenseMatrix[Complex] = (0 until 3)
+      .map { (d) =>
+        val sketch: DenseMatrix[Double] = sketcher.sketch(b(d), d)
+        fourierTr(sketch(*, ::))
+      }
+      .reduce (_ :* _)
 
-    fft_sketch_contribution1 - fft_sketch_contribution2 * Complex(alpha0 / (alpha0 + 2), 0)
+    m * Complex(a, 0.0)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -56,6 +56,7 @@ object DataCumulantSketch {
       .filter {
         case (_, len, _) => len >= 3
       }
+    validDocuments.cache()
 
     val dimVocab = validDocuments.take(1)(0)._3.length
     val numDocs = validDocuments.count()

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -71,7 +71,7 @@ object DataCumulantSketch {
 
     println("Start calculating second order moments...")
     val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = if (randomisedSVD) {
-      RandNLA.whiten(sc, alpha0,
+      RandNLA.whiten2(sc, alpha0,
         dimVocab, dimK, numDocs, firstOrderMoments, validDocuments)
     }
     else {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
@@ -4,7 +4,6 @@ import breeze.math._
 import breeze.linalg._
 import breeze.stats.distributions._
 import breeze.storage.Zero
-import org.apache.commons.math3.random.MersenneTwister
 
 /** Generate independent hash functions h and sign functions \xi */
 object HashFunctions {
@@ -18,13 +17,6 @@ object HashFunctions {
       : (Tensor[(Int, Int, Int), W], Tensor[(Int, Int, Int), Int]) = {
     // The current version only implemented for 2-wise independent hash functions
     assert(kWiseIndependent == 2)
-
-    /*implicit val randBasis: RandBasis = seed match {
-      case Some(r) =>
-        new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(r)))
-      case None =>
-        Rand
-    }*/
 
     val uniform = new Uniform(0, 1)
     val ev = implicitly[Numeric[W]]

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
@@ -8,21 +8,23 @@ import org.apache.commons.math3.random.MersenneTwister
 
 /** Generate independent hash functions h and sign functions \xi */
 object HashFunctions {
-  def apply[@specialized(Double) W : Numeric : Semiring : Zero](n: Seq[Int],
-                                b: Int,
-                                B: Int,
-                                kWiseIndependent: Int = 2,
-                                seed: Option[Int] = None
-                               )
+  def apply[@specialized(Double) W : Numeric : Semiring : Zero]
+                (n: Seq[Int],
+                 b: Int,
+                 B: Int,
+                 kWiseIndependent: Int = 2
+                )
+                (implicit randBasis: RandBasis = Rand)
       : (Tensor[(Int, Int, Int), W], Tensor[(Int, Int, Int), Int]) = {
     // The current version only implemented for 2-wise independent hash functions
     assert(kWiseIndependent == 2)
 
-    seed.foreach { sd =>
-      implicit val randBasis: RandBasis = new RandBasis(
-        new ThreadLocalRandomGenerator(new MersenneTwister(sd))
-      )
-    }
+    /*implicit val randBasis: RandBasis = seed match {
+      case Some(r) =>
+        new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(r)))
+      case None =>
+        Rand
+    }*/
 
     val uniform = new Uniform(0, 1)
     val ev = implicitly[Numeric[W]]

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -4,9 +4,10 @@ import breeze.math._
 import breeze.linalg._
 import breeze.numerics._
 import breeze.stats._
+import breeze.stats.distributions.{Rand, RandBasis}
 import breeze.storage.Zero
-import scalaxy.loops._
 
+import scalaxy.loops._
 import scala.language.postfixOps
 import scala.reflect.ClassTag
 
@@ -164,11 +165,11 @@ object TensorSketcher {
           (n: Seq[Int],
            b: Int = Math.pow(2, 12).toInt,
            B: Int = 1,
-           kWiseIndependent: Int = 2,
-           seed: Option[Int] = None)
+           kWiseIndependent: Int = 2)
+          (implicit randBasis: RandBasis = Rand)
           : TensorSketcher[V, W] =  {
     val (xi: Tensor[(Int, Int, Int), W], h: Tensor[(Int, Int, Int), Int]) =
-      HashFunctions[W](n, b, B, kWiseIndependent, seed)
+      HashFunctions[W](n, b, B, kWiseIndependent)
     new TensorSketcher[V, W](n, b, B, xi, h)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/textprocessing/TextProcessor.scala
@@ -8,9 +8,9 @@ import scala.collection.mutable
 
 
 object TextProcessor {
-  def processDocuments(sc: SparkContext, paths: String, stopwordFile: String, vocabSize: Int)
+  def processDocuments(sc: SparkContext, path: String, stopwordFile: String, vocabSize: Int)
   : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) = {
-    val textRDD: RDD[(String, String)] = sc.wholeTextFiles(paths)
+    val textRDD: RDD[(String, String)] = sc.wholeTextFiles(path)
     textRDD.cache()
 
     // Split text into words
@@ -69,11 +69,10 @@ object TextProcessor {
     (mydocuments, vocabarray)
   }
 
-  def processDocuments_libsvm(sc: SparkContext, paths: Seq[String], vocabSize: Int)
+  def processDocuments_libsvm(sc: SparkContext, path: String, vocabSize: Int)
   : (RDD[(Long, breeze.linalg.SparseVector[Double])], Array[String]) ={
-    val mypath: String = paths.mkString(",")
-    println(mypath)
-    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, mypath)
+    println(path)
+    val mydocuments: RDD[(Long, breeze.linalg.SparseVector[Double])] = loadLibSVMFile2sparseVector(sc, path)
     val vocabsize = mydocuments.take(1)(0)._2.length
     val vocabarray: Array[String] = (0 until vocabsize).toArray.map(x => x.toString)
     (mydocuments, vocabarray)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -7,21 +7,18 @@ package edu.uci.eecs.spectralLDA.utils
 
 import breeze.linalg._
 import breeze.numerics._
+import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 
 import scalaxy.loops._
 import scala.language.postfixOps
 
-object AlgebraUtil{
-  private val SEED_random: Long = System.currentTimeMillis
+object AlgebraUtil {
   private val TOLERANCE: Double = 1.0e-9
 
-  def gaussian(rows: Int, cols: Int, seed: Long = SEED_random): DenseMatrix[Double] = {
-    val vectorizedOutputMatrix: Array[Double] = new Array[Double](rows * cols)
-    val rand: scala.util.Random = new scala.util.Random(seed)
-    for (i: Int <- vectorizedOutputMatrix.indices) {
-      vectorizedOutputMatrix(i) = rand.nextGaussian()
-    }
-    val gaussianMatrix: DenseMatrix[Double] = new DenseMatrix(rows, cols, vectorizedOutputMatrix)
+  def gaussian(rows: Int, cols: Int)
+              (implicit randBasis: RandBasis = Rand): DenseMatrix[Double] = {
+    val gaussianMatrix: DenseMatrix[Double] = new DenseMatrix(rows, cols,
+      Gaussian(0, 1).sample(rows * cols).toArray)
     matrixNormalization(gaussianMatrix)
   }
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -1,0 +1,51 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import scala.util.control.Breaks._
+import scalaxy.loops._
+import scala.language.postfixOps
+
+object NonNegativeAdjustment {
+  def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
+    val M_onSimplex: DenseMatrix[Double] = DenseMatrix.zeros[Double](M.rows, M.cols)
+    for(i <- 0 until M.cols optimized){
+      val thisColumn = M(::,i)
+
+      val tmp1 = simplexProj(thisColumn)
+      val tmp2 = simplexProj(-thisColumn)
+      val err1:Double = breeze.linalg.norm(tmp1 - thisColumn)
+      val err2:Double = breeze.linalg.norm(tmp2 - thisColumn)
+      if(err1 > err2){
+        M_onSimplex(::,i) := tmp2
+      }
+      else{
+        M_onSimplex(::,i) := tmp1
+      }
+    }
+    M_onSimplex
+  }
+
+  def simplexProj(V: DenseVector[Double]): DenseVector[Double]={
+    // val z:Double = 1.0
+    val len: Int = V.length
+    val U: DenseVector[Double] = DenseVector(V.copy.toArray.sortWith(_ > _))
+    val cums: DenseVector[Double] = DenseVector(AlgebraUtil.Cumsum(U.toArray).map(x => x-1))
+    val Index: DenseVector[Double] = DenseVector((1 to (len + 1)).toArray.map(x => 1.0/x.toDouble))
+    val InterVec: DenseVector[Double] = cums :* Index
+    val TobefindMax: DenseVector[Double] = U - InterVec
+    var maxIndex : Int = 0
+    // find maxIndex
+    breakable{
+      for (i <- 0 until len optimized){
+        if (TobefindMax(len - i - 1) > 0){
+          maxIndex = len - i - 1
+          break()
+        }
+      }
+    }
+    val theta: Double = InterVec(maxIndex)
+    val W: DenseVector[Double] = V.map(x => x - theta)
+    val P_norm: DenseVector[Double] = W.map(x => if (x > 0) x else 0)
+    P_norm
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -1,6 +1,7 @@
 package edu.uci.eecs.spectralLDA.utils
 
 import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, svd}
+import breeze.stats.distributions.{Rand, RandBasis}
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
@@ -13,12 +14,13 @@ object RandNLA {
                      numDocs: Long,
                      firstOrderMoments: DenseVector[Double],
                      documents: RDD[(Long, Double, SparseVector[Double])])
+            (implicit randBasis: RandBasis = Rand)
   : (DenseMatrix[Double], DenseVector[Double]) = {
     val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
     val para_shift: Double = alpha0
 
-    val SEED_random: Long = System.currentTimeMillis
-    val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2, SEED_random)
+    //val SEED_random: Long = System.currentTimeMillis
+    val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2)
     val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
     val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -21,16 +21,13 @@ object RandNLA {
     val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
     val para_shift: Double = alpha0
 
-    //val SEED_random: Long = System.currentTimeMillis
     val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2)
     val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
-    val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
 
     val M2_a_S: DenseMatrix[Double] = documents map {
       this_document => accumulate_M_mul_S(
         vocabSize, dimK * 2,
         alpha0,
-        firstOrderMoments_broadcasted.value,
         gaussianRandomMatrix_broadcasted.value,
         this_document._3, this_document._2)
     } reduce(_ + _)
@@ -45,7 +42,6 @@ object RandNLA {
       this_document => accumulate_M_mul_S(
         vocabSize,
         dimK * 2, alpha0,
-        firstOrderMoments_broadcasted.value,
         Q,
         this_document._3, this_document._2)
     } reduce(_ + _)
@@ -73,16 +69,13 @@ object RandNLA {
     val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
     val para_shift: Double = alpha0
 
-    //val SEED_random: Long = System.currentTimeMillis
     val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2)
     val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
-    val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
 
     val M2_a_S: DenseMatrix[Double] = documents map {
       this_document => accumulate_M_mul_S(
         vocabSize, dimK * 2,
         alpha0,
-        firstOrderMoments_broadcasted.value,
         gaussianRandomMatrix_broadcasted.value,
         this_document._3, this_document._2)
     } reduce(_ + _)
@@ -97,7 +90,6 @@ object RandNLA {
       this_document => accumulate_M_mul_S(
         vocabSize,
         dimK * 2, alpha0,
-        firstOrderMoments_broadcasted.value,
         q,
         this_document._3, this_document._2)
     } reduce(_ + _)
@@ -114,9 +106,8 @@ object RandNLA {
 
 
   private def accumulate_M_mul_S(dimVocab: Int, dimK: Int, alpha0: Double,
-                                 m1: breeze.linalg.DenseVector[Double], S: breeze.linalg.DenseMatrix[Double], Wc: breeze.linalg.SparseVector[Double], len: Double) = {
+                                 S: breeze.linalg.DenseMatrix[Double], Wc: breeze.linalg.SparseVector[Double], len: Double) = {
     assert(dimVocab == Wc.length)
-    assert(dimVocab == m1.length)
     assert(dimVocab == S.rows)
     assert(dimK == S.cols)
     val len_calibrated: Double = math.max(len, 3.0)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -1,6 +1,8 @@
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, svd}
+import breeze.linalg.eigSym.EigSym
+import breeze.linalg.qr.QR
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, eigSym, qr, svd}
 import breeze.stats.distributions.{Rand, RandBasis}
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
@@ -57,6 +59,59 @@ object RandNLA {
     val eigenValues: DenseVector[Double] = s.map(entry => math.sqrt(entry))
     (eigenVectors(::, 0 until dimK), eigenValues(0 until dimK))
   }
+
+  def whiten2(sc: SparkContext,
+              alpha0: Double,
+              vocabSize: Int, dimK: Int,
+              numDocs: Long,
+              firstOrderMoments: DenseVector[Double],
+              documents: RDD[(Long, Double, SparseVector[Double])])
+            (implicit randBasis: RandBasis = Rand)
+  : (DenseMatrix[Double], DenseVector[Double]) = {
+    assert(vocabSize >= dimK * 2)
+
+    val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
+    val para_shift: Double = alpha0
+
+    //val SEED_random: Long = System.currentTimeMillis
+    val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2)
+    val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
+    val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
+
+    val M2_a_S: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize, dimK * 2,
+        alpha0,
+        firstOrderMoments_broadcasted.value,
+        gaussianRandomMatrix_broadcasted.value,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+
+    M2_a_S :*= para_main
+    val shiftedMatrix: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * gaussianRandomMatrix)
+    M2_a_S -= shiftedMatrix :* para_shift
+
+    val QR(q: DenseMatrix[Double], _) = qr.reduced(M2_a_S)
+
+    val M2_a_Q: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize,
+        dimK * 2, alpha0,
+        firstOrderMoments_broadcasted.value,
+        q,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+    M2_a_Q :*= para_main
+    val shiftedMatrix2: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * q)
+    M2_a_Q -= shiftedMatrix2 :* para_shift
+
+    // Note: eigenvectors * Diag(eigenvalues) = M2_a_Q
+    val EigSym(s: DenseVector[Double], u: DenseMatrix[Double]) = eigSym(q.t * M2_a_Q)
+    val idx = argtopk(s, dimK)
+    (q * u(::, idx).copy, s(idx).copy.toDenseVector)
+  }
+
+
 
   private def accumulate_M_mul_S(dimVocab: Int, dimK: Int, alpha0: Double,
                                  m1: breeze.linalg.DenseVector[Double], S: breeze.linalg.DenseMatrix[Double], Wc: breeze.linalg.SparseVector[Double], len: Double) = {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -1,0 +1,92 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, svd}
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.rdd.RDD
+
+
+object RandNLA {
+  def whiten(sc: SparkContext,
+                     alpha0: Double,
+                     vocabSize: Int, dimK: Int,
+                     numDocs: Long,
+                     firstOrderMoments: DenseVector[Double],
+                     documents: RDD[(Long, Double, SparseVector[Double])])
+  : (DenseMatrix[Double], DenseVector[Double]) = {
+    val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
+    val para_shift: Double = alpha0
+
+    val SEED_random: Long = System.currentTimeMillis
+    val gaussianRandomMatrix: DenseMatrix[Double] = AlgebraUtil.gaussian(vocabSize, dimK * 2, SEED_random)
+    val gaussianRandomMatrix_broadcasted: Broadcast[breeze.linalg.DenseMatrix[Double]] = sc.broadcast(gaussianRandomMatrix)
+    val firstOrderMoments_broadcasted: Broadcast[breeze.linalg.DenseVector[Double]] = sc.broadcast(firstOrderMoments.toDenseVector)
+
+    val M2_a_S: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize, dimK * 2,
+        alpha0,
+        firstOrderMoments_broadcasted.value,
+        gaussianRandomMatrix_broadcasted.value,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+
+    M2_a_S :*= para_main
+    val shiftedMatrix: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * gaussianRandomMatrix)
+    M2_a_S -= shiftedMatrix :* para_shift
+
+    val Q = AlgebraUtil.orthogonalizeMatCols(M2_a_S)
+
+    val M2_a_Q: DenseMatrix[Double] = documents map {
+      this_document => accumulate_M_mul_S(
+        vocabSize,
+        dimK * 2, alpha0,
+        firstOrderMoments_broadcasted.value,
+        Q,
+        this_document._3, this_document._2)
+    } reduce(_ + _)
+    M2_a_Q :*= para_main
+    val shiftedMatrix2: breeze.linalg.DenseMatrix[Double] = firstOrderMoments * (firstOrderMoments.t * Q)
+    M2_a_Q -= shiftedMatrix2 :* para_shift
+
+    // Note: eigenvectors * Diag(eigenvalues) = M2_a_Q
+    val svd.SVD(u: breeze.linalg.DenseMatrix[Double], s: breeze.linalg.DenseVector[Double], v: breeze.linalg.DenseMatrix[Double]) = svd(M2_a_Q.t * M2_a_Q)
+    val eigenVectors: DenseMatrix[Double] = (M2_a_Q * u) * breeze.linalg.diag(s.map(entry => 1.0 / math.sqrt(entry)))
+    val eigenValues: DenseVector[Double] = s.map(entry => math.sqrt(entry))
+    (eigenVectors(::, 0 until dimK), eigenValues(0 until dimK))
+  }
+
+  private def accumulate_M_mul_S(dimVocab: Int, dimK: Int, alpha0: Double,
+                                 m1: breeze.linalg.DenseVector[Double], S: breeze.linalg.DenseMatrix[Double], Wc: breeze.linalg.SparseVector[Double], len: Double) = {
+    assert(dimVocab == Wc.length)
+    assert(dimVocab == m1.length)
+    assert(dimVocab == S.rows)
+    assert(dimK == S.cols)
+    val len_calibrated: Double = math.max(len, 3.0)
+
+    val M2_a = breeze.linalg.DenseMatrix.zeros[Double](dimVocab, dimK)
+
+    val norm_length: Double = 1.0 / (len_calibrated * (len_calibrated - 1.0))
+    val data_mul_S: DenseVector[Double] = breeze.linalg.DenseVector.zeros[Double](dimK)
+
+    var offset = 0
+    while (offset < Wc.activeSize) {
+      val token: Int = Wc.indexAt(offset)
+      val count: Double = Wc.valueAt(offset)
+      data_mul_S += S(token, ::).t.map(x => x * count)
+      offset += 1
+    }
+
+    offset = 0
+    while (offset < Wc.activeSize) {
+      val token: Int = Wc.indexAt(offset)
+      val count: Double = Wc.valueAt(offset)
+      M2_a(token, ::) += (data_mul_S - S(token, ::).t).map(x => x * count * norm_length).t
+
+      offset += 1
+    }
+    M2_a
+  }
+
+
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -12,6 +12,10 @@ object TensorOps {
     norm(norm(m(::, *)).toDenseVector)
   }
 
+  def dmatrixNorm(m: DenseMatrix[Double]): Double = {
+    norm(norm(m(::, *)).toDenseVector)
+  }
+
   def unfoldTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
         (t: Tensor[Seq[Int], V], n: Seq[Int]): DenseMatrix[V] = {
     assert(n.length == 3)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,6 +1,6 @@
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{*, Counter, DenseMatrix, DenseVector, Tensor, max, norm}
+import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, max, norm}
 import breeze.math.{Complex, Semiring}
 import breeze.storage.Zero
 
@@ -55,5 +55,14 @@ object TensorOps {
       result(::, i) := krprod[V](A(::, i), B(::, i))
     }
     result
+  }
+
+  /** tensor product v * v.t given sparse vector v */
+  def spVectorTensorProd2d(v: SparseVector[Double]): CSCMatrix[Double] = {
+    val prod: CSCMatrix[Double] = CSCMatrix.zeros[Double](v.length, v.length)
+    for (i <- 0 until v.activeSize; j <- 0 until v.activeSize) {
+      prod(v.indexAt(i), v.indexAt(j)) = v.valueAt(i) * v.valueAt(j)
+    }
+    prod
   }
 }

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -1,13 +1,13 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
 import breeze.linalg._
-import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.stats.distributions.{Dirichlet, Multinomial, RandBasis, ThreadLocalRandomGenerator}
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 import org.scalatest._
 import org.scalatest.Matchers._
-
 import org.apache.spark.SparkContext
 import edu.uci.eecs.spectralLDA.testharness.Context
+import org.apache.commons.math3.random.MersenneTwister
 
 class TensorLDASketchTest extends FlatSpec with Matchers {
 
@@ -52,6 +52,9 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       numTokensPerDocument = 1000
     )
     val documentsRDD = sc.parallelize(documents)
+
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(347529)))
 
     val sketcher = TensorSketcher[Double, Double](
       n = Seq(3, 3, 3),

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -1,7 +1,7 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
 import breeze.linalg._
-import breeze.stats.distributions.{Dirichlet, Multinomial, RandBasis, ThreadLocalRandomGenerator}
+import breeze.stats.distributions._
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 import org.scalatest._
 import org.scalatest.Matchers._
@@ -17,6 +17,7 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
                       allTokenDistributions: DenseMatrix[Double],
                       numDocuments: Int,
                       numTokensPerDocument: Int)
+                     (implicit randBasis: RandBasis = Rand)
   : Seq[(Long, SparseVector[Double])] = {
     assert(alpha.size == allTokenDistributions.cols)
     val k = alpha.size
@@ -45,6 +46,9 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
         0.1, 0.1, 0.6, 0.1, 0.1,
         0.1, 0.1, 0.1, 0.1, 0.6))
 
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(347529)))
+
     val documents = simulateLDAData(
       alpha,
       allTokenDistributions,
@@ -52,9 +56,6 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       numTokensPerDocument = 1000
     )
     val documentsRDD = sc.parallelize(documents)
-
-    implicit val randBasis: RandBasis =
-      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(347529)))
 
     val sketcher = TensorSketcher[Double, Double](
       n = Seq(3, 3, 3),


### PR DESCRIPTION
We mainly

1. Split out the redundant code between non-sketching-based and sketching-based code
2. Make the entire code base work with a random seed `implicit val randBasis: RandBasis` so that the tests are repeatable
3. When computing M2 and its randomised eigendecomposition, change `DenseMatrix` to sparse matrix `CSCMatrix` wherever possible, to gain in speed and space
4. Other refactoring to rationalise the code organisation 