### PR TITLE
Refactor Randomised SVD and the non-negativity adjustment of topic word distributions

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -40,7 +40,7 @@ object DataCumulant {
     println("Finished calculating first order moments.")
 
     println("Start calculating second order moments...")
-    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = RandNLA.whiten2(sc, alpha0,
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = RandNLA.whiten2(alpha0,
       dimVocab, dimK, numDocs, firstOrderMoments, documents)
     println("Finished calculating second order moments and whitening matrix.")
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -72,8 +72,14 @@ object DataCumulantSketch {
 
     println("Start calculating second order moments...")
     val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = if (randomisedSVD) {
-      RandNLA.whiten2(sc, alpha0,
-        dimVocab, dimK, numDocs, firstOrderMoments, validDocuments)
+      RandNLA.whiten2(
+        alpha0,
+        dimVocab,
+        dimK,
+        numDocs,
+        firstOrderMoments,
+        validDocuments
+      )
     }
     else {
       val E_x1_x2: DenseMatrix[Double] = validDocuments

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -1,12 +1,11 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
+import org.scalatest._
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
 import breeze.linalg._
 import breeze.stats.distributions._
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
-import org.scalatest._
-import org.scalatest.Matchers._
-import org.apache.spark.SparkContext
-import edu.uci.eecs.spectralLDA.testharness.Context
 import org.apache.commons.math3.random.MersenneTwister
 
 class TensorLDASketchTest extends FlatSpec with Matchers {
@@ -40,7 +39,7 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
   }
 
   "Simulated LDA" should "be recovered" in {
-    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 10.0, 20.0)
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
     val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
       Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
         0.1, 0.1, 0.6, 0.1, 0.1,
@@ -76,15 +75,15 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
 
     // Rearrange the elements/columns of fitted_alpha and fitted_beta
     // to the order of initial alpha and beta
-    val i = argsort(fitted_alpha)
-    val sorted_beta = fitted_beta(::, i).toDenseMatrix
+    val idx = argtopk(fitted_alpha, 3)
+    val sorted_beta = fitted_beta(::, idx).toDenseMatrix
     // if one vector is all negative, multiply it by -1 to turn it positive
     for (j <- 0 until sorted_beta.cols) {
       if (max(sorted_beta(::, j)) <= 0.0) {
         sorted_beta(::, j) :*= -1.0
       }
     }
-    val sorted_alpha = fitted_alpha(i).toDenseVector
+    val sorted_alpha = fitted_alpha(idx).toDenseVector
 
     info(s"Expecting alpha: $alpha")
     info(s"Obtained alpha: $sorted_alpha")
@@ -99,5 +98,74 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
 
     norm_diff_beta should be <= 0.2
     norm_diff_alpha should be <= 4.0
+  }
+
+  "Simulated LDA" should "be recovered with randomised SVD" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(23476541L)))
+
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = DenseMatrix.rand(100, 3, Uniform(0.0, 1.0))
+    allTokenDistributions(0 until 10, 0) += 3.0
+    allTokenDistributions(10 until 20, 1) += 3.0
+    allTokenDistributions(20 until 30, 2) += 3.0
+
+
+    val s = sum(allTokenDistributions(::, *))
+    val normalisedAllTokenDistributions: DenseMatrix[Double] =
+      allTokenDistributions * diag(1.0 / s.toDenseVector)
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 10000,
+      numTokensPerDocument = 1000
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val dimK = 3
+    val sketcher = TensorSketcher[Double, Double](
+      n = Seq(dimK, dimK, dimK),
+      B = 100,
+      b = Math.pow(2, 8).toInt
+    )
+
+    val tensorLDA = new TensorLDASketch(
+      dimK = dimK,
+      alpha0 = sum(alpha(0 until dimK)),
+      sketcher = sketcher,
+      maxIterations = 200,
+      nonNegativeDocumentConcentration = true,
+      randomisedSVD = true
+    )
+
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)
+
+    // Rearrange the elements/columns of fitted_alpha and fitted_beta
+    // to the order of initial alpha and beta
+    val idx = argtopk(fitted_alpha, dimK)
+    val sorted_beta = fitted_beta(::, idx).toDenseMatrix
+    val sorted_alpha = fitted_alpha(idx).toDenseVector
+
+    val expected_alpha = alpha(0 until dimK)
+    val expected_beta = normalisedAllTokenDistributions(::, 0 until dimK)
+
+    info(s"Expecting alpha: $expected_alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+
+    info(s"Expecting beta:\n$expected_beta")
+    info(s"Obtained beta:\n$sorted_beta")
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - expected_beta
+    val diff_alpha: DenseVector[Double] = sorted_alpha - expected_alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    // norm_diff_beta = 0.011160971819766542
+    // norm_diff_alpha = 2.11096081669476
+
+    norm_diff_beta should be <= 0.015
+    norm_diff_alpha should be <= 2.5
   }
 }

--- a/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
@@ -1,11 +1,12 @@
 package edu.uci.eecs.spectralLDA.sketch
 
 import breeze.linalg._
-import breeze.stats.distributions.Uniform
+import breeze.stats.distributions.{RandBasis, ThreadLocalRandomGenerator, Uniform}
 import breeze.signal.fourierTr
 import breeze.math.Complex
 import breeze.numerics.abs
 import edu.uci.eecs.spectralLDA.utils.TensorOps
+import org.apache.commons.math3.random.MersenneTwister
 import org.scalatest._
 import org.scalatest.Matchers._
 
@@ -56,6 +57,9 @@ class TensorSketchTest extends FlatSpec with Matchers {
 
   "The inner product of two 3d tensors' sketches" should
     "be close to the tensors' inner product" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(987547)))
+
     val n: Seq[Int] = Seq(10, 10, 10)
     val b = 32
     val B = 40

--- a/src/test/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdjTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdjTest.scala
@@ -1,0 +1,33 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import org.scalatest._
+import breeze.linalg._
+
+
+class NonNegAdjTest extends FlatSpec with Matchers {
+  "Simple non-negative adjustment to vectors" should "be correct" in {
+    val inputVectors = Seq(
+      DenseVector[Double](0.5, 0.5, 0.5),
+      DenseVector[Double](0.5, 0.5, -0.5),
+      DenseVector[Double](0.3, 0.3, -0.3, -0.3, 0.1, 0.1),
+      DenseVector[Double](0.3, 0.3, 0.3, 0.3, -0.3, -0.3, -0.3, -0.3, 0.1, 0.1, 0.1, 0.1),
+      DenseVector[Double](0.1, 0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, -0.3, -0.3, -0.3, -0.3),
+      DenseVector[Double](10, 10, 10, 10, 30, 30, 30, 30, -30, -30, -30, -30)
+    )
+
+    val expectedAdjustedVectors = Seq(
+      DenseVector(0.33333333333333337, 0.33333333333333337, 0.33333333333333337),
+      DenseVector(0.5, 0.5, 0.0),
+      DenseVector(0.35, 0.35, 0.0, 0.0, 0.15000000000000002, 0.15000000000000002),
+      DenseVector(0.22499999999999995, 0.22499999999999995, 0.22499999999999995, 0.22499999999999995,
+        0.0, 0.0, 0.0, 0.0, 0.024999999999999967, 0.024999999999999967, 0.024999999999999967, 0.024999999999999967),
+      DenseVector(0.024999999999999967, 0.024999999999999967, 0.024999999999999967, 0.024999999999999967,
+        0.22499999999999995, 0.22499999999999995, 0.22499999999999995, 0.22499999999999995, 0.0, 0.0, 0.0, 0.0),
+      DenseVector(0.0, 0.0, 0.0, 0.0, 0.25, 0.25, 0.25, 0.25, 0.0, 0.0, 0.0, 0.0)
+    )
+
+    for ((v1, v2) <- inputVectors.zip(expectedAdjustedVectors)) {
+      norm(NonNegativeAdjustment.simplexProj(v1)._1 - v2) should be <= 1e-8
+    }
+  }
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/utils/RandNLATest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/utils/RandNLATest.scala
@@ -1,0 +1,108 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg._
+import breeze.linalg.qr.QR
+import breeze.stats.distributions.{Gaussian, RandBasis, ThreadLocalRandomGenerator, Uniform}
+import edu.uci.eecs.spectralLDA.testharness.Context
+import org.apache.commons.math3.random.MersenneTwister
+import org.apache.spark.SparkContext
+import org.scalatest._
+
+
+class RandNLATest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  "M2 computation" should "be correct" in {
+    val a1 = SparseVector(DenseVector.rand[Double](100).toArray)
+    val a2 = SparseVector(DenseVector.rand[Double](100).toArray)
+    val a3 = SparseVector(DenseVector.rand[Double](100).toArray)
+
+    val docs = Seq((1000L, a1), (1001L, a2), (1002L, a3))
+    val docsRDD = sc.parallelize(docs)
+
+    // Random Gaussian matrix
+    val g = DenseMatrix.rand[Double](100, 50, Gaussian(mu = 0.0, sigma = 1.0))
+
+    val result = DenseMatrix.zeros[Double](100, 50)
+    docsRDD
+      .flatMap {
+        case (id: Long, w: SparseVector[Double]) => RandNLA.accumulate_M_mul_S(g, w, sum(w))
+      }
+      .reduceByKey(_ + _)
+      .collect
+      .foreach {
+        case (r: Int, a: DenseVector[Double]) => result(r, ::) := a.t
+      }
+
+    val m2 = docsRDD
+      .map {
+        case (id: Long, w: SparseVector[Double]) =>
+          val l = sum(w)
+          (w * w.t - diag(w)) / (l * (l - 1.0))
+      }
+      .reduce(_ + _)
+    val expectedResult = m2 * g
+
+    val diff: DenseMatrix[Double] = result - expectedResult
+    val normDiff: Double = norm(norm(diff(::, *)).toDenseVector)
+    normDiff should be <= 1e-8
+  }
+
+  "Nystrom method" should "be approximately correct" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(987697)))
+
+    val n = 100
+    val k = 5
+
+    val alpha: DenseVector[Double] = DenseVector[Double](25.0, 20.0, 15.0, 10.0, 5.0)
+    val beta: DenseMatrix[Double] = DenseMatrix.rand(n, k, Uniform(0.0, 1.0))
+
+    val norms = norm(beta(::, *)).toDenseVector
+    for (j <- 0 until k) {
+      beta(::, j) /= norms(j)
+    }
+
+    val a: DenseMatrix[Double] = beta * diag(alpha) * beta.t
+    val sigma: DenseMatrix[Double] = DenseMatrix.rand(n, k, Gaussian(mu = 0.0, sigma = 1.0))
+    val y = a * sigma
+    val QR(q: DenseMatrix[Double], _) = qr.reduced(y)
+
+    val (s: DenseVector[Double], u: DenseMatrix[Double]) = RandNLA.nystrom(a * q, q)
+
+    val diff_a = u * diag(s) * u.t - a
+    val norm_diff_a = norm(norm(diff_a(::, *)).toDenseVector)
+
+    norm_diff_a should be <= 1e-8
+  }
+
+  "Nystrom-like method" should "be approximately correct" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(234787)))
+
+    val n = 100
+    val k = 5
+
+    val alpha: DenseVector[Double] = DenseVector[Double](25.0, 20.0, 15.0, 10.0, 5.0)
+    val beta: DenseMatrix[Double] = DenseMatrix.rand(n, k, Uniform(0.0, 1.0))
+
+    val norms = norm(beta(::, *)).toDenseVector
+    for (j <- 0 until k) {
+      beta(::, j) /= norms(j)
+    }
+
+    val a: DenseMatrix[Double] = beta * diag(alpha) * beta.t
+    val sigma: DenseMatrix[Double] = DenseMatrix.rand(n, k, Gaussian(mu = 0.0, sigma = 1.0))
+    val y = a * sigma
+    val QR(q: DenseMatrix[Double], _) = qr.reduced(y)
+
+    val (s: DenseVector[Double], u: DenseMatrix[Double]) = RandNLA.decomp2(a * q, q)
+
+    val diff_a = u * diag(s) * u.t - a
+    val norm_diff_a = norm(norm(diff_a(::, *)).toDenseVector)
+
+    norm_diff_a should be <= 1e-8
+  }
+}
+

--- a/src/test/scala/edu/uci/eecs/spectralLDA/utils/RandNLATest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/utils/RandNLATest.scala
@@ -13,7 +13,7 @@ class RandNLATest extends FlatSpec with Matchers {
 
   private val sc: SparkContext = Context.getSparkContext
 
-  "M2 computation" should "be correct" in {
+  "M2 sketching" should "be correct" in {
     val a1 = SparseVector(DenseVector.rand[Double](100).toArray)
     val a2 = SparseVector(DenseVector.rand[Double](100).toArray)
     val a3 = SparseVector(DenseVector.rand[Double](100).toArray)
@@ -77,7 +77,7 @@ class RandNLATest extends FlatSpec with Matchers {
     norm_diff_a should be <= 1e-8
   }
 
-  "Nystrom-like method" should "be approximately correct" in {
+  "Randomised Power Iteration method" should "be approximately correct" in {
     implicit val randBasis: RandBasis =
       new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(234787)))
 


### PR DESCRIPTION
We mainly refactored the randomised SVD, and the non-negativity adjustment for post-processing of the fitted topic word distributions. 

* For the Randomised SVD, we follow the Randomised Power Iteration method in Musco & Musco 2016, in which they proved the bounds on individual eigenvectors as well. I tested the original code and the Nystrom method, both perform less as well. 
* For the non-negativity adjustment, we follow Duchi 2008. For a fitted topic word distribution vector beta, we project both beta and -beta into the l1-simplex, then check the shift theta as computed by both projections, and retain whichever projected vector with the larger shift theta. 

Ref:
Musco, Cameron, & Christopher Musco, Randomized Block Krylov Methods for Stronger and Faster Approximate Singular Value Decomposition, 2016
Duchi, John, Efficient Projections onto the l1-Ball for Learning in High Dimensions, 2008