### PR TITLE
Refactoring

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -8,7 +8,7 @@
  import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
  import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
  import breeze.linalg.{DenseMatrix, DenseVector}
- import breeze.stats.distributions.{Rand, RandBasis}
+ import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
  import org.apache.spark.rdd.RDD
  import org.apache.spark.SparkContext
 
@@ -25,9 +25,10 @@ class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
     val T: breeze.linalg.DenseMatrix[Double] = myData.thirdOrderMoments
     val unwhiteningMatrix: DenseMatrix[Double] = myData.unwhiteningMatrix
 
-    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
-    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
-    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
+    var A: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var B: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var C: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
 
     var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
     var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -8,13 +8,12 @@
  import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
  import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
  import breeze.linalg.{DenseMatrix, DenseVector}
- import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
+ import breeze.stats.distributions.{Rand, RandBasis, Gaussian}
  import org.apache.spark.rdd.RDD
  import org.apache.spark.SparkContext
 
  import scalaxy.loops._
  import scala.language.postfixOps
- import scala.util.control.Breaks._
  import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
 
 class ALS(dimK: Int, myData: DataCumulant) extends Serializable{

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -8,7 +8,7 @@ import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
-import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
+import breeze.stats.distributions.{Rand, RandBasis, Gaussian}
 import breeze.stats.median
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 
@@ -17,7 +17,7 @@ import scala.language.postfixOps
 class ALSSketch(dimK: Int,
                 fft_sketch_T: DenseMatrix[Complex],
                 sketcher: TensorSketcher[Double, Double],
-                maxIterations: Int = 1000
+                maxIterations: Int = 200
                 ) extends Serializable {
 
   def run(implicit randBasis: RandBasis = Rand)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -8,7 +8,7 @@ import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
 import breeze.linalg.{*, DenseMatrix, DenseVector}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
-import breeze.stats.distributions.{Rand, RandBasis}
+import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 import breeze.stats.median
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 
@@ -22,9 +22,10 @@ class ALSSketch(dimK: Int,
 
   def run(implicit randBasis: RandBasis = Rand)
         : (DenseMatrix[Double], DenseVector[Double]) = {
-    var A: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
-    var B: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
-    var C: DenseMatrix[Double] = AlgebraUtil.gaussian(dimK, dimK)
+    val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
+    var A: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var B: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var C: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
 
     var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
     var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -12,7 +12,7 @@ import org.apache.spark.rdd.RDD
 
 class TensorLDA(dimK: Int,
                 alpha0: Double,
-                maxIterations: Int = 1000,
+                maxIterations: Int = 200,
                 tolerance: Double = 1e-9)
                 extends Serializable {
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -13,12 +13,13 @@ import org.apache.spark.rdd.RDD
 
 class TensorLDASketch(dimK: Int,
                       alpha0: Double,
-                      maxIterations: Int = 1000,
+                      maxIterations: Int = 200,
                       sketcher: TensorSketcher[Double, Double],
                       randomisedSVD: Boolean = true,
                       nonNegativeDocumentConcentration: Boolean = true)
                      (implicit tolerance: Double = 1e-9)
   extends Serializable {
+  assert(sketcher.n forall { _ == dimK }, s"The sketcher must work on symmetric tensors of shape ($dimK, ..., $dimK).")
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
@@ -20,17 +20,17 @@ object HashFunctions {
     */
   def apply[@specialized(Double) W : Numeric : Semiring : Zero]
                 (n: Seq[Int],
-                 b: Int,
-                 B: Int,
+                 b: Int = Math.pow(2, 8).toInt,
+                 B: Int = 50,
                  kWiseIndependent: Int = 2
                 )
                 (implicit randBasis: RandBasis = Rand)
       : (Tensor[(Int, Int, Int), W], Tensor[(Int, Int, Int), Int]) = {
     // The current version only implemented for 2-wise independent hash functions
-    for (d <- n) assert(d > 0)
-    assert(b > 0)
-    assert(B > 0)
-    assert(kWiseIndependent == 2)
+    assert(n forall { _ > 0 }, "Each dimension size must be positive.")
+    assert(b > 0, "The hash length b must be positive.")
+    assert(B > 0, "The number of hash families B must be positive.")
+    assert(kWiseIndependent == 2, "Currently only 2-wise independent hash functions are implemented.")
 
     val uniform = new Uniform(0, 1)
     val ev = implicitly[Numeric[W]]

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/HashFunctions.scala
@@ -7,6 +7,17 @@ import breeze.storage.Zero
 
 /** Generate independent hash functions h and sign functions \xi */
 object HashFunctions {
+  /** Generate independent hash functions
+    *
+    * @param n   Length-q Seq (d_1, ..., d_q), q is the order of the tensor, d_i the size along dimension i
+    * @param b   Length of each hash
+    * @param B   Number of hash families
+    * @param kWiseIndependent k-wise independent hash functions, 2 for current implementation
+    * @param randBasis    Random seed
+    * @tparam W  The space of hashed values, Double or Complex
+    * @return    B-by-q-by-d_i tensor for the sign functions \xi, and
+    *            B-by-q-by-d_i tensor for the hash functions h
+    */
   def apply[@specialized(Double) W : Numeric : Semiring : Zero]
                 (n: Seq[Int],
                  b: Int,
@@ -16,6 +27,9 @@ object HashFunctions {
                 (implicit randBasis: RandBasis = Rand)
       : (Tensor[(Int, Int, Int), W], Tensor[(Int, Int, Int), Int]) = {
     // The current version only implemented for 2-wise independent hash functions
+    for (d <- n) assert(d > 0)
+    assert(b > 0)
+    assert(B > 0)
     assert(kWiseIndependent == 2)
 
     val uniform = new Uniform(0, 1)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketch.scala
@@ -42,6 +42,9 @@ class TensorSketcher[@specialized(Double) V : Numeric : ClassTag : Semiring : Ze
          val xi: Tensor[(Int, Int, Int), W],
          val h: Tensor[(Int, Int, Int), Int])
   extends TensorSketcherBase[V, W] with Serializable {
+  assert(n forall { _ > 0 }, "Each dimension size must be positive.")
+  assert(b > 0, "The hash length b must be positive.")
+  assert(B > 0, "The number of hash families B must be positive.")
 
   // order of the tensor
   val p: Int = n.size
@@ -163,8 +166,8 @@ object TensorSketcher {
   def apply[@specialized(Double) V : Numeric : ClassTag : Semiring : Zero,
             @specialized(Double) W : Numeric : ClassTag : Semiring : Zero]
           (n: Seq[Int],
-           b: Int = Math.pow(2, 12).toInt,
-           B: Int = 1,
+           b: Int = Math.pow(2, 8).toInt,
+           B: Int = 50,
            kWiseIndependent: Int = 2)
           (implicit randBasis: RandBasis = Rand)
           : TensorSketcher[V, W] =  {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -21,23 +21,6 @@ object AlgebraUtil {
     val to_be_inverted: DenseMatrix[Double] = ctc :* btb
     breeze.linalg.pinv(to_be_inverted)
   }
-  
-  def orthogonalizeMatCols(B: DenseMatrix[Double]): DenseMatrix[Double] = {
-    val A:DenseMatrix[Double] = B.copy
-
-    for (j <- 0 until A.cols optimized) {
-      for (i <- 0 until j optimized) {
-        val dotij = A(::, j) dot A(::, i)
-        A(::, j) :-= (A(::, i) :* dotij)
-
-      }
-      val normsq_sqrt: Double = Math.sqrt(A(::, j) dot A(::, j))
-      val scale: Double = if (normsq_sqrt > TOLERANCE) 1.0 / normsq_sqrt else 1e-12
-      A(::, j) :*= scale
-    }
-    A
-  }
-
 
   def colWiseNorm2(A: breeze.linalg.DenseMatrix[Double]): breeze.linalg.DenseVector[Double] = {
     val normVec = breeze.linalg.DenseVector.zeros[Double](A.cols)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -94,10 +94,7 @@ object AlgebraUtil {
     delta < TOLERANCE
   }
 
-
   def Cumsum(xs: Array[Double]): Array[Double] = {
-    // def apply(xs : Seq[Int]) : Seq[Int] =
-    //   xs.scanLeft(0)(_ + _).tail
     xs.scanLeft(0.0)(_ + _).tail
   }
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -15,21 +15,13 @@ import scala.language.postfixOps
 object AlgebraUtil {
   private val TOLERANCE: Double = 1.0e-9
 
-  def gaussian(rows: Int, cols: Int)
-              (implicit randBasis: RandBasis = Rand): DenseMatrix[Double] = {
-    val gaussianMatrix: DenseMatrix[Double] = new DenseMatrix(rows, cols,
-      Gaussian(0, 1).sample(rows * cols).toArray)
-    matrixNormalization(gaussianMatrix)
-  }
-
   def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
     val ctc: DenseMatrix[Double] = c.t * c
     val btb: DenseMatrix[Double] = b.t * b
     val to_be_inverted: DenseMatrix[Double] = ctc :* btb
     breeze.linalg.pinv(to_be_inverted)
   }
-
-
+  
   def orthogonalizeMatCols(B: DenseMatrix[Double]): DenseMatrix[Double] = {
     val A:DenseMatrix[Double] = B.copy
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -48,7 +48,7 @@ object RandNLA {
     var q = DenseMatrix.rand[Double](vocabSize, dimK + slackDimK, Gaussian(mu = 0.0, sigma = 1.0))
     var m2q: DenseMatrix[Double] = null
 
-    for (i <- 0 until 2 * (1 + nIter)) {
+    for (i <- 0 until 2 * nIter + 1) {
       m2q = randomProjectM2(
         alpha0,
         vocabSize,

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketchTest.scala
@@ -1,7 +1,7 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
 import breeze.linalg._
-import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.stats.distributions.{Dirichlet, Multinomial, RandBasis, ThreadLocalRandomGenerator}
 import breeze.signal.fourierTr
 import breeze.math.Complex
 import breeze.numerics.abs
@@ -11,12 +11,16 @@ import org.scalatest.Matchers._
 import org.apache.spark.SparkContext
 import edu.uci.eecs.spectralLDA.utils.TensorOps
 import edu.uci.eecs.spectralLDA.testharness.Context
+import org.apache.commons.math3.random.MersenneTwister
 
 class ALSSketchTest extends FlatSpec with Matchers {
 
   private val sc: SparkContext = Context.getSparkContext
 
   "T(C katri-rao dot B) via sketching" should "be close to the exact result" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(23476541L)))
+
     val k: Int = 20
     val p: DenseVector[Double] = DenseVector.rand(k)
     val t: Tensor[Seq[Int], Double] = Counter()
@@ -26,7 +30,7 @@ class ALSSketchTest extends FlatSpec with Matchers {
 
     val sketcher = TensorSketcher[Double, Double](
       n = Seq(k, k, k),
-      B = 100,
+      B = 50,
       b = Math.pow(2, 8).toInt
     )
 

--- a/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/sketch/TensorSketchTest.scala
@@ -101,7 +101,7 @@ class TensorSketchTest extends FlatSpec with Matchers {
     abs(delta) should be <= 0.05
   }
 
-  "Sketch of rank-1 3d tensor" should "be the convolution of the sketches along each dimension" in {
+  "Sketch of rank-1 3d tensor" should "be the convolution of the 3 sketches of vector along each dimension" in {
     val n = Seq(3, 3, 3)
     val sketcher = TensorSketcher[Double, Double](
       n = n,
@@ -131,7 +131,7 @@ class TensorSketchTest extends FlatSpec with Matchers {
   }
 
   "Sketch of whitened rank-1 3d tensor" should
-    "be the convolution of sketches of whitened vectors along each dimension" in {
+    "be the convolution of the 3 sketches of whitened vector along each dimension" in {
     val v: Seq[DenseVector[Double]] = Seq(
       DenseVector.rand(50),
       DenseVector.rand(50),
@@ -170,7 +170,7 @@ class TensorSketchTest extends FlatSpec with Matchers {
     TensorOps.matrixNorm(fft_sketch_whitened_t - prod_fft_sketch_whitened_v) should be <= 1e-6
   }
 
-  "Sketch of whitened diagonal matrix" should "be the expected sum of sketches" in {
+  "Sketch of sum of rank-1 2d tensors (W\\diag(v)W^*)" should "be the sum of expected sketches" in {
     val v: DenseVector[Double] = DenseVector.rand(50)
     val t: DenseMatrix[Double] = diag(v)
 


### PR DESCRIPTION
We did final clean up and refactoring for the part of sketching-based Spectral LDA.

1. Add input arguments check for the `HashFunctions` and `TensorSketcher` constructors
2. Updated the default number of hash family B=50, hash length b=2^8, default max number of iterations for ALS =200 after repetitive test runs
3. Add comments, clean up 