### PR TITLE
Update for Spark 2.0.0 and Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Now if we run the above experiments again, any "WARN BLAS" or "WARN LAPACK" mess
 ## Who do I talk to?
 
 * Repo owner or admin: Furong Huang 
-* Contact: furongh@uci.edu
+* Contact: furongh.uci@gmail.com

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "SpectralLDA-Tensor"
 
 version := "1.0"
 
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.8"
 crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 
@@ -42,7 +42,7 @@ libraryDependencies ++= Seq(
 
 
 {
-  val defaultSparkVersion = "[1.6.1,)"
+  val defaultSparkVersion = "[2.0.0,)"
   val sparkVersion =
     scala.util.Properties.envOrElse("SPARK_VERSION", defaultSparkVersion)
 


### PR DESCRIPTION
Spark 2.0.0 is newly released and compiles with Scala 2.11 by default. We update `build.sbt` and `README.md` accordingly.

1. In `build.sbt` now the Scala version by default is 2.11. We can still cross build to Scala 2.10. `README.md` explains this point with more detail.
2. Updated instruction on how to set up Spark 2.0.0 to have native support for BLAS/LAPACK. 