### PR TITLE
add non-negative ALS to help convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Now if we run the above experiments again, any "WARN BLAS" or "WARN LAPACK" mess
 ### I have millions of small text files...
 If we open them simply via `sc.wholeTextFiles()` the system will spend forever long time querying the file system for the list of all the file names. The solution is to first combine them in Hadoop SequenceFiles of `RDD[(String, String)]`, then process them into word count vectors and vocabulary array.
 
-1. We provided `edu.uci.eecs.spectralLDA.textprocessing.CombineSmallTextFiles` to squash many text files into a Hadoop SequenceFile. For example, all the Wikipedia articles are extracted under `wikitext/0` to `wikitext/9999`, with each subdirectory containing thousands of text files.
+1. We provided `edu.uci.eecs.spectralLDA.textprocessing.CombineSmallTextFiles` to squash many text files into a Hadoop SequenceFile. As an example, if all the Wikipedia articles are extracted under `wikitext/0` to `wikitext/9999`, with thousands of text files under each subdirectory, we could batch combining them into a series of SequenceFiles.
 
     ```bash
     # Under wikitext/, first list all the subdirectory names,
@@ -160,18 +160,17 @@ If we open them simply via `sc.wholeTextFiles()` the system will spend forever l
     target/scala-2.11/spectrallda-tensor_2.11-1.0.jar
     ```
     
-    When the loop finishes, we'd find many `*.obj` Hadoop SequenceFiles under `wikitext/`.
+    When the loop finishes, we'd find a number of `*.obj` Hadoop SequenceFiles under `wikitext/`.
     
-2. Within `sbt console`, we process the SequenceFiles into word count vectors `RDD[(Long, SparseVector[Double])]` and dictionary array, and save them. 
+2. Launch `spark-shell` with the proper server and memory settings, and the option `--jars target/scala-2.11/spectrallda-tensor_2.11-1.0.jar`. 
+
+   We process the SequenceFiles into word count vectors `RDD[(Long, SparseVector[Double])]` and dictionary array, and save them. 
 
     ```scala
-    import org.apache.spark.{SparkConf, SparkContext}
     import org.apache.spark.rdd.RDD
     import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
-    val conf = new SparkConf().setAppName("Word Count")
-    val sc = new SparkContext(conf)
     val (docs, dictionary) = TextProcessor.processDocumentsRDD(
-      sc.objectFile("wikitext/*.obj"),
+      sc.objectFile[(String, String)]("wikitext/*.obj"),
       stopwordFile = "src/main/resources/Data/datasets/StopWords_common.txt",
       vocabSize = <vocabSize>
     )

--- a/README.md
+++ b/README.md
@@ -85,15 +85,11 @@ val lda = new TensorLDASketch(
   dimK = params.k,
   alpha0 = params.topicConcentration,
   sketcher = sketcher,
+  idfLowerBound = value,                     // optional, default: 1.0
   m2ConditionNumberUB = value,               // optional, default: infinity
   maxIterations = 200,                       // optional, default: 200
-  nonNegativeDocumentConcentration = true,   // optional, default: true
   randomisedSVD = true                       // optional, default: true
 )(tolerance = params.tolerance)              // optional, default: 1e-9
-
-// If we want to only work on terms with IDF above a certain bound
-// import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
-// val filteredDocs = TextProcessor.filterIDF(documents, <IDF lower bound>)
 
 // Fit against the documents
 // beta is the V-by-k matrix, where V is the vocabulary size, 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -170,7 +170,7 @@ object SpectralLDA {
     println("Generated the SparkConetxt")
 
     println("Start reading data...")
-    val (rawDocuments: RDD[(Long, SparseVector[Double])], vocabArray: Array[String]) = params.inputType match {
+    val (documents: RDD[(Long, SparseVector[Double])], vocabArray: Array[String]) = params.inputType match {
       case "libsvm" =>
         TextProcessor.processDocuments_libsvm(sc, params.input.mkString(","), params.vocabSize)
       case "text" =>
@@ -178,8 +178,6 @@ object SpectralLDA {
       case "obj" =>
         (sc.objectFile[(Long, SparseVector[Double])](params.input.mkString(",")), Array[String]())
     }
-
-    val documents = TextProcessor.filterIDF(rawDocuments, params.idfLowerBound)
 
     println("Finished reading data.")
 
@@ -195,6 +193,7 @@ object SpectralLDA {
         dimK = params.k,
         alpha0 = params.topicConcentration,
         sketcher = sketcher,
+        idfLowerBound = params.idfLowerBound,
         m2ConditionNumberUB = params.m2ConditionNumberUB,
         maxIterations = params.maxIterations,
         nonNegativeDocumentConcentration = true,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -196,7 +196,6 @@ object SpectralLDA {
         idfLowerBound = params.idfLowerBound,
         m2ConditionNumberUB = params.m2ConditionNumberUB,
         maxIterations = params.maxIterations,
-        nonNegativeDocumentConcentration = true,
         randomisedSVD = true
       )(tolerance = params.tolerance)
       lda.fit(documents)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -213,12 +213,12 @@ object SpectralLDA {
     println("Finished ALS algorithm for tensor decomposition.")
 
     val preprocessElapsed: Double = (System.nanoTime() - preprocessStart) / 1e9
-    val numDocs: Long = documents.count()
+    val numDocs: Double = documents.countApprox(30000L).getFinalValue.mean
     val dimVocab: Int = documents.map(_._2.length).take(1)(0)
     sc.stop()
     println()
     println("Corpus summary:")
-    println(s"\t Training set size: $numDocs documents")
+    println(s"\t Training set size: ~$numDocs documents")
     println(s"\t Vocabulary size: $dimVocab terms")
     println(s"\t Model Training time: $preprocessElapsed sec")
     println()

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -7,8 +7,8 @@
  */
  import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
  import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
- import breeze.linalg.{DenseMatrix, DenseVector}
- import breeze.stats.distributions.{Rand, RandBasis, Gaussian}
+ import breeze.linalg.{*, DenseMatrix, DenseVector, norm}
+ import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
  import org.apache.spark.rdd.RDD
  import org.apache.spark.SparkContext
 
@@ -43,7 +43,7 @@ class ALS(dimK: Int, myData: DataCumulant) extends Serializable{
       for (idx <- 0 until dimK optimized) {
         A(idx, ::) := A_array(idx).t
       }
-      lambda = AlgebraUtil.colWiseNorm2(A)
+      lambda = norm(A(::, *)).toDenseVector
       A = AlgebraUtil.matrixNormalization(A)
 
       // println("Mode B...")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -5,10 +5,10 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Alternating Least Square algorithm is implemented.
   */
 import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
-import breeze.linalg.{*, DenseMatrix, DenseVector}
+import breeze.linalg.{*, DenseMatrix, DenseVector, norm}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
-import breeze.stats.distributions.{Rand, RandBasis, Gaussian}
+import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 import breeze.stats.median
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 
@@ -38,7 +38,7 @@ class ALSSketch(dimK: Int,
 
       // println("Mode A...")
       A = updateALSiteration(fft_sketch_T, B, C, sketcher)
-      lambda = AlgebraUtil.colWiseNorm2(A)
+      lambda = norm(A(::, *)).toDenseVector
       A = AlgebraUtil.matrixNormalization(A)
 
       // println("Mode B...")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -4,8 +4,8 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Tensor Decomposition Algorithms.
   * Alternating Least Square algorithm is implemented.
   */
-import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
-import breeze.linalg.{*, DenseMatrix, DenseVector, max, min, norm}
+import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, NonNegativeAdjustment}
+import breeze.linalg.{*, DenseMatrix, DenseVector, max, min, norm, pinv}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
 import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
@@ -14,6 +14,23 @@ import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 
 import scala.language.postfixOps
 
+/** Sketched tensor decomposition by Alternating Least Square (ALS)
+  *
+  * Suppose dimK-by-dimK-by-dimK tensor T can be decomposed as sum of rank-1 tensors
+  *
+  *    T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i
+  *
+  * If we pool all the column vectors \lambda_i a_i in A, b_i in B, c_i in C, then
+  *
+  *    T^{1} = A (C \khatri-rao product B)^{\top}
+  *
+  * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
+  *
+  * @param dimK          tensor T is of shape dimK-by-dimK-by-dimK
+  * @param fft_sketch_T  FFT of sketched tensor T
+  * @param sketcher      the sketching facility
+  * @param maxIterations max iterations for the ALS algorithm
+  */
 class ALSSketch(dimK: Int,
                 fft_sketch_T: DenseMatrix[Complex],
                 sketcher: TensorSketcher[Double, Double],
@@ -57,7 +74,7 @@ class ALSSketch(dimK: Int,
     (A, lambda)
   }
 
-  private def updateALSiteration(fft_sketch_T: DenseMatrix[Complex],
+  def updateALSiteration(fft_sketch_T: DenseMatrix[Complex],
                                  B: DenseMatrix[Double],
                                  C: DenseMatrix[Double],
                                  sketcher: TensorSketcher[Double, Double])
@@ -71,6 +88,79 @@ class ALSSketch(dimK: Int,
     // T * (C katri-rao dot B) * pinv((C^T C) :* (B^T B))
     // i.e T * pinv((C katri-rao dot B)^T)
     TIBC * Inverted
+  }
+}
+
+/** Non-negative sketched tensor decomposition by Alternating Least Square (ALS)
+  *
+  * Suppose dimK-by-dimK-by-dimK tensor T can be decomposed as sum of rank-1 tensors
+  *
+  *    T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i
+  *
+  * If we pool all the column vectors \lambda_i a_i in A, b_i in B, c_i in C, then
+  *
+  *    T^{1} = A (C \khatri-rao product B)^{\top}
+  *
+  * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
+  *
+  * Furthermore, given a V-by-dimK matrix H, the solution will satisfy
+  *
+  *    Ha_i >= 0, Hb_i >= 0, Hc_i >= 0, and Ha_i, Hb_i, Hc_i sum up to 1, \forall i\in [1,dimK].
+  *
+  * @param dimK          tensor T is of shape dimK-by-dimK-by-dimK
+  * @param fft_sketch_T  FFT of sketched tensor T
+  * @param sketcher      the sketching facility
+  * @param h             matrix H
+  * @param maxIterations max iterations for the ALS algorithm
+  */
+class NNALSSketch(dimK: Int,
+                  fft_sketch_T: DenseMatrix[Complex],
+                  sketcher: TensorSketcher[Double, Double],
+                  h: DenseMatrix[Double],
+                  maxIterations: Int = 200
+                 )
+  extends ALSSketch(dimK, fft_sketch_T, sketcher, maxIterations) {
+
+  override def run(implicit randBasis: RandBasis)
+      : (DenseMatrix[Double], DenseVector[Double]) = {
+    val hInv = pinv(h.t * h) * h.t
+
+    val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
+    var A: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var B: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    var C: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+
+    var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
+    var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)
+    var iter: Int = 0
+
+    println("Start ALS iterations...")
+
+    while ((iter == 0) || ((iter < maxIterations) && !AlgebraUtil.isConverged(A_prev, A))) {
+      A_prev = A.copy
+
+      // println("Mode A...")
+      val refA = updateALSiteration(fft_sketch_T, B, C, sketcher)
+      A = hInv * NonNegativeAdjustment.simplexProj_Matrix(h * refA)
+      lambda = norm(A(::, *)).toDenseVector
+      println(s"lambda: max ${max(lambda)}, min ${min(lambda)}")
+      A = AlgebraUtil.matrixNormalization(A)
+
+      // println("Mode B...")
+      val refB = updateALSiteration(fft_sketch_T, C, A, sketcher)
+      B = hInv * NonNegativeAdjustment.simplexProj_Matrix(h * refB)
+      B = AlgebraUtil.matrixNormalization(B)
+
+      // println("Mode C...")
+      val refC = updateALSiteration(fft_sketch_T, A, B, sketcher)
+      C = hInv * NonNegativeAdjustment.simplexProj_Matrix(h * refC)
+      C = AlgebraUtil.matrixNormalization(C)
+
+      iter += 1
+    }
+    println("Finished ALS iterations.")
+
+    (A, lambda)
   }
 }
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -5,7 +5,7 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Alternating Least Square algorithm is implemented.
   */
 import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, NonNegativeAdjustment}
-import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, pinv}
+import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, pinv, sum}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
 import breeze.numerics._
@@ -146,6 +146,7 @@ class NNALSSketch(dimK: Int,
       // println("Mode A...")
       val refA = updateALSiteration(fft_sketch_T, B, C, sketcher)
       A = hInv * NonNegativeAdjustment.simplexProj_Matrix(h * refA)
+      println(s"sum(HA) ${sum(h * A)}\tmin(HA) ${min(h * A)}")
       lambda = norm(A(::, *)).toDenseVector
       println(s"lambda: max ${max(lambda)}, min ${min(lambda)}")
       A = AlgebraUtil.matrixNormalization(A)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -5,7 +5,7 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Alternating Least Square algorithm is implemented.
   */
 import edu.uci.eecs.spectralLDA.utils.AlgebraUtil
-import breeze.linalg.{*, DenseMatrix, DenseVector, norm}
+import breeze.linalg.{*, DenseMatrix, DenseVector, max, min, norm}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
 import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
@@ -39,6 +39,7 @@ class ALSSketch(dimK: Int,
       // println("Mode A...")
       A = updateALSiteration(fft_sketch_T, B, C, sketcher)
       lambda = norm(A(::, *)).toDenseVector
+      println(s"lambda: max ${max(lambda)}, min ${min(lambda)}")
       A = AlgebraUtil.matrixNormalization(A)
 
       // println("Mode B...")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -50,7 +50,7 @@ class TensorLDASketch(dimK: Int,
     // unwhitening matrix: $(W^T)^{-1}=U\Sigma^{1/2}$
     val unwhiteningMatrix = cumulantSketch.eigenVectorsM2 * diag(sqrt(cumulantSketch.eigenValuesM2))
 
-    val alpha: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2)) * alpha0
+    val alpha: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
     val topicWordMatrix: breeze.linalg.DenseMatrix[Double] = unwhiteningMatrix * nu * diag(lambda)
 
     // Diagnostic information: the ratio of the maximum to the minimum of the

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -43,7 +43,8 @@ class TensorLDASketch(dimK: Int,
       dimK,
       cumulantSketch.fftSketchWhitenedM3,
       sketcher,
-      cumulantSketch.eigenVectorsM2 * diag(sqrt(cumulantSketch.eigenValuesM2)),
+      cumulantSketch.eigenVectorsM2,
+      cumulantSketch.eigenValuesM2,
       maxIterations = maxIterations
     )
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -16,6 +16,7 @@ class TensorLDASketch(dimK: Int,
                       alpha0: Double,
                       maxIterations: Int = 200,
                       sketcher: TensorSketcher[Double, Double],
+                      idfLowerBound: Double = 1.0,
                       m2ConditionNumberUB: Double = Double.PositiveInfinity,
                       randomisedSVD: Boolean = true,
                       nonNegativeDocumentConcentration: Boolean = true)
@@ -33,6 +34,7 @@ class TensorLDASketch(dimK: Int,
       dimK, alpha0,
       documents,
       sketcher,
+      idfLowerBound = idfLowerBound,
       m2ConditionNumberUB = m2ConditionNumberUB,
       randomisedSVD = randomisedSVD
     )

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -9,6 +9,7 @@ import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, diag, max
 import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
 import org.apache.spark.rdd.RDD
 
 class TensorLDASketch(dimK: Int,
@@ -73,6 +74,6 @@ class TensorLDASketch(dimK: Int,
             "output reasonable results. It could be due to the existence of very frequent words " +
             "across the documents or that the specified k is larger than the true number of topics.")
 
-    (topicWordMatrix, alpha)
+    (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -94,7 +94,7 @@ object DataCumulantSketch {
         .map(_ / numDocs.toDouble).toDenseMatrix
       val M2: DenseMatrix[Double] = E_x1_x2 - alpha0 / (alpha0 + 1) * (firstOrderMoments * firstOrderMoments.t)
 
-      val eigSym.EigSym(sigma, u) = eigSym((alpha0 + 1) * M2)
+      val eigSym.EigSym(sigma, u) = eigSym(alpha0 * (alpha0 + 1) * M2)
       val i = argsort(sigma)
       (u(::, i.slice(dimVocab - dimK, dimVocab)).copy, sigma(i.slice(dimVocab - dimK, dimVocab)).copy)
     }
@@ -193,7 +193,7 @@ object DataCumulantSketch {
     println("Finished calculating third order moments.")
 
     new DataCumulantSketch(
-      fft_sketch_whitened_M3 * Complex((alpha0 + 1) * (alpha0 + 2) / 2.0, 0),
+      fft_sketch_whitened_M3 * Complex(alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0, 0),
       eigenVectors,
       eigenValues
     )

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -22,22 +22,12 @@ object AlgebraUtil {
     breeze.linalg.pinv(to_be_inverted)
   }
 
-  def colWiseNorm2(A: breeze.linalg.DenseMatrix[Double]): breeze.linalg.DenseVector[Double] = {
-    val normVec = breeze.linalg.DenseVector.zeros[Double](A.cols)
-    for (i <- 0 until A.cols optimized) {
-      val thisnorm: Double = Math.sqrt(A(::, i) dot A(::, i))
-      normVec(i) = (if (thisnorm > TOLERANCE) thisnorm else TOLERANCE)
-    }
-    normVec
-  }
-
-
   def matrixNormalization(B: DenseMatrix[Double]): DenseMatrix[Double] = {
     val A: DenseMatrix[Double] = B.copy
-    val colNorms: DenseVector[Double] = sqrt(diag(A.t * A))
+    val colNorms: DenseVector[Double] = norm(A(::, *)).toDenseVector
 
     for (i <- 0 until A.cols optimized) {
-      A(::, i) :*= (if (colNorms(i) > TOLERANCE) (1.0 / colNorms(i)) else TOLERANCE)
+      A(::, i) :/= colNorms(i)
     }
     A
   }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -81,7 +81,11 @@ object AlgebraUtil {
     val numerator: Double = breeze.linalg.norm(newA.toDenseVector - oldA.toDenseVector)
     val denominator: Double = breeze.linalg.norm(newA.toDenseVector)
     val delta: Double = numerator / denominator
-    delta < TOLERANCE
+
+    val dprod = diag(oldA.t * newA)
+    println(s"delta: $delta\tdot: ${diag(oldA.t * newA)}")
+    //delta < TOLERANCE
+    all(dprod :> 0.99)
   }
 
   def Cumsum(xs: Array[Double]): Array[Double] = {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -8,14 +8,10 @@ import scala.language.postfixOps
 
 object NonNegativeAdjustment {
   def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
-    val M_onSimplex: DenseMatrix[Double] = DenseMatrix.zeros[Double](M.rows, M.cols)
+    val M_onSimplex = DenseMatrix.zeros[Double](M.rows, M.cols)
     for(i <- 0 until M.cols optimized){
-      val thisColumn = M(::,i)
-
-      val (tmp1, theta1) = simplexProj(thisColumn)
-      val (tmp2, theta2) = simplexProj(-thisColumn)
-
-      M_onSimplex(::, i) := (if (theta1 > theta2) tmp1 else tmp2)
+      val (projectedVector, _) = simplexProj(M(::, i))
+      M_onSimplex(::, i) := projectedVector
     }
 
     M_onSimplex

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -166,8 +166,8 @@ object RandNLA {
                                      documents: RDD[(Long, Double, SparseVector[Double])],
                                      q: DenseMatrix[Double]
                                     ): DenseMatrix[Double] = {
-    val para_main: Double = (alpha0 + 1.0) / numDocs.toDouble
-    val para_shift: Double = alpha0
+    val para_main: Double = (alpha0 + 1.0) * alpha0
+    val para_shift: Double = alpha0 * alpha0
 
     val unshiftedM2 = DenseMatrix.zeros[Double](vocabSize, dimK + slackDimK)
     val qBroadcast = documents.sparkContext.broadcast[DenseMatrix[Double]](q)
@@ -182,6 +182,7 @@ object RandNLA {
       .foreach {
         case (token, v) => unshiftedM2(token, ::) := v.t
       }
+    unshiftedM2 /= numDocs.toDouble
     qBroadcast.unpersist
 
     val m2 = unshiftedM2 * para_main - (firstOrderMoments * (firstOrderMoments.t * q)) * para_shift

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -40,6 +40,7 @@ object RandNLA {
               numDocs: Long,
               firstOrderMoments: DenseVector[Double],
               documents: RDD[(Long, Double, SparseVector[Double])],
+              termsLowIDF: Seq[Int] = Seq[Int](),
               nIter: Int = 1)
             (implicit randBasis: RandBasis = Rand)
   : (DenseMatrix[Double], DenseVector[Double]) = {
@@ -60,7 +61,8 @@ object RandNLA {
         numDocs,
         firstOrderMoments,
         documents,
-        q
+        q,
+        termsLowIDF
       )
       val QR(nextq, _) = qr.reduced(m2q)
       q = nextq
@@ -74,7 +76,8 @@ object RandNLA {
       numDocs,
       firstOrderMoments,
       documents,
-      q
+      q,
+      termsLowIDF
     )
 
     // Randomised eigendecomposition of M2
@@ -164,13 +167,18 @@ object RandNLA {
                                      numDocs: Long,
                                      firstOrderMoments: DenseVector[Double],
                                      documents: RDD[(Long, Double, SparseVector[Double])],
-                                     q: DenseMatrix[Double]
+                                     q: DenseMatrix[Double],
+                                     termsLowIDF: Seq[Int] = Seq[Int]()
                                     ): DenseMatrix[Double] = {
     val para_main: Double = (alpha0 + 1.0) * alpha0
     val para_shift: Double = alpha0 * alpha0
 
-    val unshiftedM2 = DenseMatrix.zeros[Double](vocabSize, dimK + slackDimK)
+    firstOrderMoments(termsLowIDF) := 0.0
+    q(termsLowIDF, ::) := 0.0
+
     val qBroadcast = documents.sparkContext.broadcast[DenseMatrix[Double]](q)
+
+    val unshiftedM2 = DenseMatrix.zeros[Double](vocabSize, dimK + slackDimK)
     documents
       .flatMap {
         doc => accumulate_M_mul_S(
@@ -183,6 +191,8 @@ object RandNLA {
         case (token, v) => unshiftedM2(token, ::) := v.t
       }
     unshiftedM2 /= numDocs.toDouble
+    unshiftedM2(termsLowIDF, ::) := 0.0
+
     qBroadcast.unpersist
 
     val m2 = unshiftedM2 * para_main - (firstOrderMoments * (firstOrderMoments.t * q)) * para_shift

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/RandNLA.scala
@@ -40,7 +40,7 @@ object RandNLA {
               numDocs: Long,
               firstOrderMoments: DenseVector[Double],
               documents: RDD[(Long, Double, SparseVector[Double])],
-              nIter: Int = 3)
+              nIter: Int = 1)
             (implicit randBasis: RandBasis = Rand)
   : (DenseMatrix[Double], DenseVector[Double]) = {
     assert(vocabSize >= dimK)

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -67,7 +67,6 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       alpha0 = sum(alpha),
       sketcher = sketcher,
       maxIterations = 200,
-      nonNegativeDocumentConcentration = true,
       randomisedSVD = false
     )
 
@@ -138,7 +137,6 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       alpha0 = sum(alpha(0 until dimK)),
       sketcher = sketcher,
       maxIterations = 200,
-      nonNegativeDocumentConcentration = true,
       randomisedSVD = true
     )
 

--- a/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketchTest.scala
@@ -128,8 +128,8 @@ class DataCumulantSketchTest extends FlatSpec with Matchers {
 
     // Compute shifted M2, M3
     val (shiftedM2: DenseMatrix[Double], shiftedM3: DenseMatrix[Double]) = shiftMoments(M1, E_x1_x2, E_x1_x2_x3, alpha0)
-    val scaledShiftedM2 = shiftedM2 * (alpha0 + 1)
-    val scaledShiftedM3 = shiftedM3 * ((alpha0 + 1) * (alpha0 + 2) / 2.0)
+    val scaledShiftedM2 = shiftedM2 * alpha0 * (alpha0 + 1)
+    val scaledShiftedM3 = shiftedM3 * (alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0)
 
     // Eigendecomposition of shiftedM2
     val eigSym.EigSym(sigma, u) = eigSym(scaledShiftedM2)


### PR DESCRIPTION
1. It used to be very hard for the ALS to converge on real data sets. Now at each iteration in the ALS, we first solve for refA

        T = refA (C \katri-rao prod B)^{\top}

  As final topic word distribution = H refA, where H is the un-whitening matrix, we cast H refA into the l1-simplex to obtain refBeta, then compute

      A = inv(H.t * H) * H.t * refBeta

  and proceed with normalisation of columns of A.

2. The ALS convergence criteria is now written as 

        diag(prevA.t * A) > 0.99

    (Mathematically it could be translated to Euclidean distance).

With the heuristic above the algorithm usually converges (or converges for most of the k topics), and produces interpretable results.