### PR TITLE
Log-likelihood computation

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -1,0 +1,63 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, all, diag, sum}
+import breeze.numerics.{abs, lgamma, log}
+import breeze.stats.distributions.Dirichlet
+import org.apache.spark.rdd.RDD
+
+
+class TensorLDAModel(val beta: DenseMatrix[Double],
+                     val alpha: DenseVector[Double])
+    extends Serializable {
+  /** compute sum of loglikelihood(doc|topics over the doc, alpha, beta) */
+  def logLikelihood(docs: RDD[(Long, SparseVector[Double])],
+                    maxIterationsEM: Int = 3,
+                    lowerBound: Double = Double.NegativeInfinity)
+      : Double = {
+    docs
+      .map {
+        case (id: Long, wordCounts: SparseVector[Double]) =>
+          val topicDistribution: DenseVector[Double] = inferEM(wordCounts, maxIterationsEM)
+          val ll = TensorLDAModel.multinomialLogLikelihood(beta * topicDistribution, wordCounts)
+          Math.max(lowerBound, ll)
+      }
+      .sum
+  }
+
+  def inferEM(wordCounts: SparseVector[Double], maxIterationsEM: Int)
+      : DenseVector[Double] = {
+    var prior = alpha.copy
+    var topicDistributionSample: DenseVector[Double] = null
+
+    for (i <- 0 until maxIterationsEM) {
+      topicDistributionSample = new Dirichlet(prior).sample()
+      // println(s"prior $prior, sample $topicDistributionSample")
+
+      val expectedWordCounts: DenseVector[Double] = beta * topicDistributionSample
+      val latentTopicAttribution: DenseMatrix[Double] =
+        diag(1.0 / expectedWordCounts) * (beta * diag(topicDistributionSample))
+
+      val wordCountsPerTopic = diag(wordCounts) * latentTopicAttribution
+      val priorIncrement: DenseVector[Double] = sum(wordCountsPerTopic(::, *)).toDenseVector
+      assert(abs(sum(priorIncrement) - sum(wordCounts)) <= 1e-6)
+
+      prior += priorIncrement
+    }
+
+    topicDistributionSample
+  }
+}
+
+private[algorithm] object TensorLDAModel {
+  /** compute the loglikelihood of sample x for multinomial(p) */
+  def multinomialLogLikelihood(p: DenseVector[Double],
+                               x: Vector[Double])
+      : Double = {
+    assert(p.length == x.length)
+    assert(p forall(_ >= 0.0))
+    assert(x forall(_ >= 0.0))
+
+    val coeff: Double = lgamma(sum(x) + 1) - sum(x.map(a => lgamma(a + 1)))
+    coeff + sum(x :* log(p))
+  }
+}

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -19,8 +19,8 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
   private val vocabSize = topicWordDistribution.rows
 
   // smoothing so that beta is positive
-  val beta = topicWordDistribution * (1 - smoothing)
-    + smoothing / vocabSize * DenseMatrix.ones[Double](vocabSize, k)
+  val beta: DenseMatrix[Double] = topicWordDistribution * (1 - smoothing)
+  beta += DenseMatrix.ones[Double](vocabSize, k) * (smoothing / vocabSize)
 
   assert(sum(beta(::, *)).toDenseVector.forall(a => abs(a - 1) <= 1e-10))
   assert(beta.forall(_ > 1e-10))

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -74,8 +74,8 @@ private[algorithm] object TensorLDAModel {
                                x: Vector[Double])
       : Double = {
     assert(p.length == x.length)
-    assert(p forall(_ >= 0.0))
-    assert(x forall(_ >= 0.0))
+    assert(p forall(_ > - 1e-12))
+    assert(x forall(_ > - 1e-12))
 
     val coeff: Double = lgamma(sum(x) + 1) - sum(x.map(a => lgamma(a + 1)))
     coeff + sum(x :* log(p))

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -59,7 +59,7 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
       }
 
       val priorIncrement: DenseVector[Double] = sum(wordCountsPerTopic(::, *)).toDenseVector
-      assert(abs(sum(priorIncrement) - sum(wordCounts)) <= 1e-6)
+      // assert(abs(sum(priorIncrement) - sum(wordCounts)) <= 1e-6)
 
       prior += priorIncrement
     }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -128,8 +128,8 @@ object DataCumulantSketch {
 
     val firstOrderMoments_whitened = W.t * firstOrderMoments
 
-    val broadcasted_W = sc.broadcast(W)
-    val broadcasted_sketcher = sc.broadcast(sketcher)
+    val broadcasted_W = sc.broadcast[DenseMatrix[Double]](W)
+    val broadcasted_sketcher = sc.broadcast[TensorSketcher[Double, Double]](sketcher)
 
     // First order terms: p^{\otimes 3}, p\otimes p\otimes q, p\otimes q\otimes p,
     // q\otimes p\otimes p

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
@@ -29,7 +29,7 @@ class TensorLDAModelTest extends FlatSpec with Matchers {
     val wordCounts1 = SparseVector[Double](70, 20, 10, 0, 0)
     val wordCounts2 = SparseVector[Double](10, 20, 70, 10, 20)
 
-    val ldaModel = new TensorLDAModel(beta, alpha)
+    val ldaModel = new TensorLDAModel(beta, alpha)(smoothing = 0.0)
 
     val topicDistribution1 = ldaModel.inferEM(wordCounts1, maxIterationsEM = 20)
     val topicDistribution2 = ldaModel.inferEM(wordCounts2, maxIterationsEM = 20)

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
@@ -1,0 +1,44 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, norm}
+import breeze.numerics.abs
+import org.scalatest._
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
+
+class TensorLDAModelTest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  "Multinomial log-likelihood" should "be correct" in {
+    val p = DenseVector[Double](0.2, 0.5, 0.3)
+    val x1 = DenseVector[Double](20, 50, 30)
+    val x2 = DenseVector[Double](40, 40, 20)
+
+    abs(TensorLDAModel.multinomialLogLikelihood(p, x1) - (-4.697546)) should be <= 1e-6
+    abs(TensorLDAModel.multinomialLogLikelihood(p, x2) - (-15.42038)) should be <= 1e-6
+  }
+
+  "Topic distribution EM inference" should "be loosely close to expected" in {
+    val beta = new DenseMatrix[Double](5, 3, Array[Double]
+      (0.6, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.6, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.6))
+    val alpha = DenseVector[Double](20.0, 50.0, 30.0)
+
+    val wordCounts1 = SparseVector[Double](70, 20, 10, 0, 0)
+    val wordCounts2 = SparseVector[Double](10, 20, 70, 10, 20)
+
+    val ldaModel = new TensorLDAModel(beta, alpha)
+
+    val topicDistribution1 = ldaModel.inferEM(wordCounts1, maxIterationsEM = 20)
+    val topicDistribution2 = ldaModel.inferEM(wordCounts2, maxIterationsEM = 20)
+
+    val expectedTopicDistribution1 = DenseVector[Double](0.7, 0.2, 0.1)
+    val expectedTopicDistribution2 = DenseVector[Double](0.1, 0.7, 0.2)
+
+    norm(expectedTopicDistribution1 - topicDistribution1) should be <= 0.25
+    norm(expectedTopicDistribution2 - topicDistribution2) should be <= 0.25
+  }
+}
+


### PR DESCRIPTION
Add log-likelihood computation. For every document, the topic distribution is deduced with EM iteratively.