### PR TITLE
Add the variational lower bound to the log-likelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ val lda = new TensorLDASketch(
 // k is the number of topics. It stores the word distribution 
 // per topic column-wise
 // alpha is the length-k Dirichlet prior for the topic distribution
-val (beta: DenseMatrix[Double], alpha: DenseVector[Double]) = lda.fit(documents)
+// eigvecM2 is the V-by-k matrix of the top k eigenvectors of M2
+// eigvalM2 is the length-k vector of the top k eigenvalues of M2
+val (beta: DenseMatrix[Double], alpha: DenseVector[Double], eigvecM2: DenseMatrix[Double], eigvalM2: DenseVector[Double]) = lda.fit(documents)
 ```
 
 For non-sketching-based decomposition, the usage is simpler.

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -198,7 +198,8 @@ object SpectralLDA {
         maxIterations = params.maxIterations,
         randomisedSVD = true
       )(tolerance = params.tolerance)
-      lda.fit(documents)
+      val (beta_, alpha_, _, _) = lda.fit(documents)
+      (beta_, alpha_)
     }
     else {
       val lda = new TensorLDA(

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -4,8 +4,9 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Tensor Decomposition Algorithms.
   * Alternating Least Square algorithm is implemented.
   */
+import breeze.linalg.qr.QR
 import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, NonNegativeAdjustment}
-import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, pinv, sum}
+import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, pinv, qr, sum}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
 import breeze.numerics._
@@ -41,9 +42,13 @@ class ALSSketch(dimK: Int,
   def run(implicit randBasis: RandBasis = Rand)
         : (DenseMatrix[Double], DenseVector[Double]) = {
     val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
-    var A: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
-    var B: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
-    var C: DenseMatrix[Double] = DenseMatrix.rand[Double](dimK, dimK, gaussian)
+    val qr.QR(randA, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+    var qr.QR(randB, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+    var qr.QR(randC, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
+
+    var A: DenseMatrix[Double] = randA
+    var B: DenseMatrix[Double] = randB
+    var C: DenseMatrix[Double] = randC
 
     var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
     var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -57,7 +57,7 @@ class ALSSketch(dimK: Int,
       // println("Mode A...")
       A = updateALSiteration(fft_sketch_T, B, C, sketcher)
       lambda = norm(A(::, *)).toDenseVector
-      println(s"lambda: max ${max(lambda)}, min ${min(lambda)}")
+      println(s"iter $iter\tlambda: max ${max(lambda)}, min ${min(lambda)}")
       A = AlgebraUtil.matrixNormalization(A)
 
       // println("Mode B...")
@@ -146,9 +146,9 @@ class NNALSSketch(dimK: Int,
       // println("Mode A...")
       val refA = updateALSiteration(fft_sketch_T, B, C, sketcher)
       A = hInv * NonNegativeAdjustment.simplexProj_Matrix(h * refA)
-      println(s"sum(HA) ${sum(h * A)}\tmin(HA) ${min(h * A)}")
+      println(s"iter $iter\tsum(HA) ${sum(h * A)}\tmin(HA) ${min(h * A)}")
       lambda = norm(A(::, *)).toDenseVector
-      println(s"lambda: max ${max(lambda)}, min ${min(lambda)}")
+      println(s"iter $iter\tlambda: max ${max(lambda)}, min ${min(lambda)}")
       A = AlgebraUtil.matrixNormalization(A)
 
       // println("Mode B...")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -1,6 +1,6 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
-import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, diag, norm, sum}
+import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, diag, norm, pinv, sum}
 import breeze.numerics.{abs, lgamma, log, sqrt}
 import breeze.stats.distributions.{Dirichlet, Rand, RandBasis}
 import org.apache.spark.rdd.RDD
@@ -31,15 +31,56 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
 
   private val whitenedBeta = whiteningMatrix.t * smoothedBeta
 
-  /** compute sum of loglikelihood(doc|topics over the doc, alpha, beta) */
+  /** Compute sum of loglikelihood(doc|topics over the doc, alpha, beta) */
   def logLikelihood(docs: RDD[(Long, SparseVector[Double])],
                     maxIterationsEM: Int = 3)
       : Double = {
     docs
       .map {
         case (id: Long, wordCounts: SparseVector[Double]) =>
+          val topicDistribution: DenseVector[Double] = inferTopicDistribution(smoothedBeta,
+            wordCounts, maxIterationsEM)
+          TensorLDAModel.multinomialLogLikelihood(smoothedBeta * topicDistribution, wordCounts)
+      }
+      .sum
+  }
+
+  /** Approximately compute sum of loglikelihood(doc|topics over the doc, alpha, beta)
+    *
+    * We feed whitened beta and wordCounts to inferTopicDistribution to accelerate
+    *
+    * */
+  def logLikelihoodApprox1(docs: RDD[(Long, SparseVector[Double])],
+                               maxIterationsEM: Int = 3)
+      : Double = {
+    docs
+      .map {
+        case (id: Long, wordCounts: SparseVector[Double]) =>
           val topicDistribution: DenseVector[Double] = inferTopicDistribution(whitenedBeta,
               whiteningMatrix.t * wordCounts, maxIterationsEM)
+          TensorLDAModel.multinomialLogLikelihood(smoothedBeta * topicDistribution, wordCounts)
+      }
+      .sum
+  }
+
+  /** Approximately compute sum of loglikelihood(doc|topics over the doc, alpha, beta)
+    *
+    * We find the topicDistribution by simple linear regression
+    *
+    *    beta * topicDistribution = wordCounts
+    *
+    * */
+  def logLikelihoodApprox2(docs: RDD[(Long, SparseVector[Double])])
+      : Double = {
+    val linearRegressionMultiplier: DenseMatrix[Double] =
+      pinv(smoothedBeta.t * smoothedBeta) * smoothedBeta.t
+    val linearRegressionMultiplierBroadcast = docs.sparkContext.broadcast(linearRegressionMultiplier)
+
+    docs
+      .map {
+        case (id: Long, wordCounts: SparseVector[Double]) =>
+          val topicDistribution: DenseVector[Double] =
+            linearRegressionMultiplierBroadcast.value * wordCounts
           TensorLDAModel.multinomialLogLikelihood(smoothedBeta * topicDistribution, wordCounts)
       }
       .sum
@@ -71,9 +112,14 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
     val expectedWordCounts: DenseVector[Double] = beta * topicDistributionSample
     val priorIncrement: Seq[Double] = for {
       j <- 0 until k
+
+      // latentTopicAttribution is a vocabSize-by-k matrix which stores the probability
+      // that $word_i$ is attributed to $topic_j$, $1\le i\le vocabSize$, $1\le j\le k$.
       latentTopicAttribution = beta(::, j) * topicDistributionSample(j) / expectedWordCounts
-      wordCountsCurrentTopic = wordCounts :* latentTopicAttribution
-    } yield sum(wordCountsCurrentTopic)
+
+      
+      wordCountsCurrentTopic = wordCounts.t * latentTopicAttribution
+    } yield wordCountsCurrentTopic
 
     val updatedPrior = topicDistributionPrior + DenseVector[Double](priorIncrement: _*)
     assert(updatedPrior.forall(_ > 0.0))

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -2,7 +2,7 @@ package edu.uci.eecs.spectralLDA.algorithm
 
 import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, diag, max, norm, sum}
 import breeze.numerics._
-import breeze.stats.distributions.{Dirichlet, Gamma, Rand, RandBasis}
+import breeze.stats.distributions.Gamma
 import org.apache.spark.rdd.RDD
 
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -100,12 +100,9 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
                  smoothing: Double = 0.01)
       : DenseMatrix[Double] = {
     // smoothing so that beta is positive
-    val totalTermCounts: DenseVector[Double] = docs.map { _._2 }.reduce(_ + _).toDenseVector
-    val averageTermCounts: DenseVector[Double] = totalTermCounts / docs.count.toDouble
 
     val smoothedBeta: DenseMatrix[Double] = topicWordDistribution * (1 - smoothing)
-    // smoothedBeta += DenseMatrix.ones[Double](vocabSize, k) * (smoothing / vocabSize)
-    smoothedBeta += (averageTermCounts / sum(averageTermCounts)) * DenseVector.ones[Double](k).t * smoothing
+    smoothedBeta += DenseMatrix.ones[Double](vocabSize, k) * (smoothing / vocabSize)
 
     assert(sum(smoothedBeta(::, *)).toDenseVector.forall(a => abs(a - 1) <= 1e-10))
     assert(smoothedBeta.forall(_ > 1e-10))

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModel.scala
@@ -1,15 +1,13 @@
 package edu.uci.eecs.spectralLDA.algorithm
 
-import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, diag, norm, sum}
-import breeze.numerics.{abs, lgamma, log, sqrt}
-import breeze.stats.distributions.{Dirichlet, Rand, RandBasis}
+import breeze.linalg.{*, DenseMatrix, DenseVector, SparseVector, Vector, diag, max, norm, sum}
+import breeze.numerics._
+import breeze.stats.distributions.{Dirichlet, Gamma, Rand, RandBasis}
 import org.apache.spark.rdd.RDD
 
 
 class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
-                     val alpha: DenseVector[Double],
-                     val eigenVectorsM2: DenseMatrix[Double],
-                     val eigenValuesM2: DenseVector[Double])
+                     val alpha: DenseVector[Double])
                     (implicit smoothing: Double = 0.01)
     extends Serializable {
 
@@ -20,71 +18,99 @@ class TensorLDAModel(val topicWordDistribution: DenseMatrix[Double],
   private val k = alpha.length
   private val vocabSize = topicWordDistribution.rows
 
-  private val whiteningMatrix: DenseMatrix[Double] = eigenVectorsM2 * diag(1.0 / sqrt(eigenValuesM2))
-
-  // smoothing so that beta is positive
-  val smoothedBeta: DenseMatrix[Double] = topicWordDistribution * (1 - smoothing)
-  smoothedBeta += DenseMatrix.ones[Double](vocabSize, k) * (smoothing / vocabSize)
-
-  assert(sum(smoothedBeta(::, *)).toDenseVector.forall(a => abs(a - 1) <= 1e-10))
-  assert(smoothedBeta.forall(_ > 1e-10))
-
-  private val whitenedBeta = whiteningMatrix.t * smoothedBeta
-
   /** Compute sum of loglikelihood(doc|topics over the doc, alpha, beta) */
   def logLikelihood(docs: RDD[(Long, SparseVector[Double])],
-                    maxIterationsEM: Int = 3)
+                    smoothing: Double,
+                    maxIterations: Int)
       : Double = {
-    docs
-      .map {
-        case (id: Long, wordCounts: SparseVector[Double]) =>
-          val topicDistribution: DenseVector[Double] = inferTopicDistribution(smoothedBeta,
-            wordCounts, maxIterationsEM)
-          TensorLDAModel.multinomialLogLikelihood(smoothedBeta * topicDistribution, wordCounts)
-      }
-      .sum
+    val smoothedBeta = smoothBeta(smoothing)
+    logLikelihoodBound(docs, smoothedBeta, gammaShape = 1.0, maxIterations = maxIterations)
   }
 
-  def inferTopicDistribution(beta: DenseMatrix[Double],
-                             wordCounts: Vector[Double],
-                             maxIterationsEM: Int)
-                            (implicit randBasis: RandBasis = Rand)
-  : DenseVector[Double] = {
-    var prior = alpha.copy
-    for (i <- 0 until maxIterationsEM) {
-      val updatedPrior = stepEM(prior, beta, wordCounts)
-      prior = updatedPrior
+  def variationalTopicInference(termCounts: SparseVector[Double],
+                                beta: DenseMatrix[Double],
+                                gammaShape: Double,
+                                maxIterations: Int)
+      : DenseVector[Double] = {
+    // Initialize the variational distribution q(theta|gamma) for the mini-batch
+    val gammad = new Gamma(gammaShape, 1.0 / gammaShape).samplesVector(k)        // K
+    val expElogthetad: DenseVector[Double] = exp(TensorLDAModel.dirichletExpectation(gammad))  // K
+    val expElogbetad = beta(termCounts.activeKeysIterator.toSeq, ::).toDenseMatrix    // ids * K
+
+    val phiNorm: DenseVector[Double] = expElogbetad * expElogthetad :+ 1e-100            // ids
+    var meanGammaChange = 1D
+    val ctsVector = DenseVector[Double](termCounts.activeValuesIterator.toSeq: _*)                                         // ids
+
+    // Iterate between gamma and phi until convergence
+    var iter = 0
+    while (iter < maxIterations && meanGammaChange > 1e-3) {
+      val lastgamma = gammad.copy
+      //        K                  K * ids               ids
+      gammad := (expElogthetad :* (expElogbetad.t * (ctsVector :/ phiNorm))) :+ alpha
+      expElogthetad := exp(TensorLDAModel.dirichletExpectation(gammad))
+      // TODO: Keep more values in log space, and only exponentiate when needed.
+      phiNorm := expElogbetad * expElogthetad :+ 1e-100
+      meanGammaChange = sum(abs(gammad - lastgamma)) / k
+
+      iter += 1
     }
 
-    new Dirichlet(prior).sample()
+    gammad
   }
 
-  /** Update the topic distribution prior by EM */
-  private def stepEM(topicDistributionPrior: DenseVector[Double],
-                     beta: DenseMatrix[Double],
-                     wordCounts: Vector[Double])
-                    (implicit randBasis: RandBasis = Rand)
-      : DenseVector[Double] = {
-    val topicDistributionSample: DenseVector[Double] =
-      new Dirichlet(topicDistributionPrior).sample()
+  def logLikelihoodBound(documents: RDD[(Long, SparseVector[Double])],
+                         beta: DenseMatrix[Double],
+                         gammaShape: Double,
+                         maxIterations: Int): Double = {
+    // transpose because dirichletExpectation normalizes by row and we need to normalize
+    // by topic (columns of lambda)
+    val Elogbeta: DenseMatrix[Double] = log(beta)
+    val ElogbetaBc = documents.sparkContext.broadcast(Elogbeta)
 
-    val expectedWordCounts: DenseVector[Double] = beta * topicDistributionSample
-    val priorIncrement: Seq[Double] = for {
-      j <- 0 until k
+    // Sum bound components for each document:
+    //  component for prob(tokens) + component for prob(document-topic distribution)
+    val corpusPart = documents
+      .filter(_._2.activeSize > 0)
+      .map {
+        case (id: Long, termCounts: SparseVector[Double]) =>
+          val localElogbeta = ElogbetaBc.value
+          var docBound = 0.0D
+          val gammad: DenseVector[Double] = variationalTopicInference(
+            termCounts, beta, gammaShape, maxIterations)
+          val Elogthetad: DenseVector[Double] = TensorLDAModel.dirichletExpectation(gammad)
 
-      // latentTopicAttribution is a vocabSize-by-k matrix which stores the probability
-      // that $word_i$ is attributed to $topic_j$, $1\le i\le vocabSize$, $1\le j\le k$.
-      // For given word index $i$, latentTopicAttribution(i, ::) sums to 1.
-      latentTopicAttribution = beta(::, j) * topicDistributionSample(j) / expectedWordCounts
+          // E[log p(doc | theta, beta)]
+          termCounts.foreachPair { case (idx, count) =>
+            docBound += count * TensorLDAModel.logSumExp(Elogthetad + localElogbeta(idx, ::).t)
+          }
 
-      // total word counts for the current topic
-      wordCountsCurrentTopic = wordCounts.t * latentTopicAttribution
-    } yield wordCountsCurrentTopic
+          // E[log p(theta | alpha) - log q(theta | gamma)]
+          docBound += sum((alpha - gammad) :* Elogthetad)
+          docBound += sum(lgamma(gammad) - lgamma(alpha))
+          docBound += lgamma(sum(alpha)) - lgamma(sum(gammad))
 
-    val updatedPrior = topicDistributionPrior + DenseVector[Double](priorIncrement: _*)
-    assert(updatedPrior.forall(_ > 0.0))
+          docBound
+      }
+      .sum()
 
-    updatedPrior
+    corpusPart
+  }
+
+
+  def smoothBeta(smoothing: Double = 0.01)
+      : DenseMatrix[Double] = {
+    // smoothing so that beta is positive
+    // val totalTermCounts: DenseVector[Double] = docs.map { _._2 }.reduce(_ + _).toDenseVector
+    // val averageTermCounts: DenseVector[Double] = totalTermCounts / docs.count.toDouble
+
+    val smoothedBeta: DenseMatrix[Double] = topicWordDistribution * (1 - smoothing)
+    smoothedBeta += DenseMatrix.ones[Double](vocabSize, k) * (smoothing / vocabSize)
+    // smoothedBeta += (averageTermCounts / sum(averageTermCounts)) * DenseVector.ones[Double](k).t * smoothing
+
+    assert(sum(smoothedBeta(::, *)).toDenseVector.forall(a => abs(a - 1) <= 1e-10))
+    assert(smoothedBeta.forall(_ > 1e-10))
+
+    smoothedBeta
   }
 }
 
@@ -99,5 +125,14 @@ private[algorithm] object TensorLDAModel {
 
     val coeff: Double = lgamma(sum(x) + 1) - sum(x.map(a => lgamma(a + 1)))
     coeff + sum(x :* log(p))
+  }
+
+  def dirichletExpectation(alpha: DenseVector[Double]): DenseVector[Double] = {
+    digamma(alpha) - digamma(sum(alpha))
+  }
+
+  def logSumExp(x: DenseVector[Double]): Double = {
+    val a = max(x)
+    a + log(sum(exp(x :- a)))
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketch.scala
@@ -29,7 +29,7 @@ class TensorLDASketch(dimK: Int,
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)
-  : (DenseMatrix[Double], DenseVector[Double]) = {
+  : (DenseMatrix[Double], DenseVector[Double], DenseMatrix[Double], DenseVector[Double]) = {
     val cumulantSketch: DataCumulantSketch = DataCumulantSketch.getDataCumulant(
       dimK, alpha0,
       documents,
@@ -75,6 +75,7 @@ class TensorLDASketch(dimK: Int,
             "output reasonable results. It could be due to the existence of very frequent words " +
             "across the documents or that the specified k is larger than the true number of topics.")
 
-    (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha)
+    (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha,
+      cumulantSketch.eigenVectorsM2, cumulantSketch.eigenValuesM2)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -13,7 +13,6 @@ import scalaxy.loops._
 import scala.language.postfixOps
 
 object AlgebraUtil {
-  private val TOLERANCE: Double = 1.0e-9
 
   def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
     val ctc: DenseMatrix[Double] = c.t * c
@@ -74,18 +73,16 @@ object AlgebraUtil {
     Out.t
   }
 
-  def isConverged(oldA: DenseMatrix[Double], newA: DenseMatrix[Double]): Boolean = {
+  def isConverged(oldA: DenseMatrix[Double], newA: DenseMatrix[Double])
+                 (implicit dotThreshold: Double = 0.99): Boolean = {
     if (oldA == null || oldA.size == 0) {
       return false
     }
-    val numerator: Double = breeze.linalg.norm(newA.toDenseVector - oldA.toDenseVector)
-    val denominator: Double = breeze.linalg.norm(newA.toDenseVector)
-    val delta: Double = numerator / denominator
 
     val dprod = diag(oldA.t * newA)
-    println(s"delta: $delta\tdot: ${diag(oldA.t * newA)}")
-    //delta < TOLERANCE
-    all(dprod :> 0.99)
+    println(s"dot(oldA, newA): ${diag(oldA.t * newA)}")
+
+    all(dprod :> dotThreshold)
   }
 
   def Cumsum(xs: Array[Double]): Array[Double] = {

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
@@ -29,10 +29,11 @@ class TensorLDAModelTest extends FlatSpec with Matchers {
     val wordCounts1 = SparseVector[Double](70, 20, 10, 0, 0)
     val wordCounts2 = SparseVector[Double](10, 20, 70, 10, 20)
 
-    val ldaModel = new TensorLDAModel(beta, alpha)(smoothing = 0.0)
+    val ldaModel = new TensorLDAModel(beta, alpha,
+      DenseMatrix.eye[Double](5), DenseVector.ones[Double](5))(smoothing = 0.0)
 
-    val topicDistribution1 = ldaModel.inferEM(wordCounts1, maxIterationsEM = 20)
-    val topicDistribution2 = ldaModel.inferEM(wordCounts2, maxIterationsEM = 20)
+    val topicDistribution1 = ldaModel.inferTopicDistribution(ldaModel.smoothedBeta, wordCounts1, maxIterationsEM = 20)
+    val topicDistribution2 = ldaModel.inferTopicDistribution(ldaModel.smoothedBeta, wordCounts2, maxIterationsEM = 20)
 
     val expectedTopicDistribution1 = DenseVector[Double](0.7, 0.2, 0.1)
     val expectedTopicDistribution2 = DenseVector[Double](0.1, 0.7, 0.2)

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDAModelTest.scala
@@ -18,28 +18,5 @@ class TensorLDAModelTest extends FlatSpec with Matchers {
     abs(TensorLDAModel.multinomialLogLikelihood(p, x1) - (-4.697546)) should be <= 1e-6
     abs(TensorLDAModel.multinomialLogLikelihood(p, x2) - (-15.42038)) should be <= 1e-6
   }
-
-  "Topic distribution EM inference" should "be loosely close to expected" in {
-    val beta = new DenseMatrix[Double](5, 3, Array[Double]
-      (0.6, 0.1, 0.1, 0.1, 0.1,
-        0.1, 0.1, 0.6, 0.1, 0.1,
-        0.1, 0.1, 0.1, 0.1, 0.6))
-    val alpha = DenseVector[Double](20.0, 50.0, 30.0)
-
-    val wordCounts1 = SparseVector[Double](70, 20, 10, 0, 0)
-    val wordCounts2 = SparseVector[Double](10, 20, 70, 10, 20)
-
-    val ldaModel = new TensorLDAModel(beta, alpha,
-      DenseMatrix.eye[Double](5), DenseVector.ones[Double](5))(smoothing = 0.0)
-
-    val topicDistribution1 = ldaModel.inferTopicDistribution(ldaModel.smoothedBeta, wordCounts1, maxIterationsEM = 20)
-    val topicDistribution2 = ldaModel.inferTopicDistribution(ldaModel.smoothedBeta, wordCounts2, maxIterationsEM = 20)
-
-    val expectedTopicDistribution1 = DenseVector[Double](0.7, 0.2, 0.1)
-    val expectedTopicDistribution2 = DenseVector[Double](0.1, 0.7, 0.2)
-
-    norm(expectedTopicDistribution1 - topicDistribution1) should be <= 0.25
-    norm(expectedTopicDistribution2 - topicDistribution2) should be <= 0.25
-  }
 }
 

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDASketchTest.scala
@@ -70,7 +70,7 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       randomisedSVD = false
     )
 
-    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double], _, _) = tensorLDA.fit(documentsRDD)
 
     // Rearrange the elements/columns of fitted_alpha and fitted_beta
     // to the order of initial alpha and beta
@@ -140,7 +140,7 @@ class TensorLDASketchTest extends FlatSpec with Matchers {
       randomisedSVD = true
     )
 
-    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double]) = tensorLDA.fit(documentsRDD)
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double], _, _) = tensorLDA.fit(documentsRDD)
 
     // Rearrange the elements/columns of fitted_alpha and fitted_beta
     // to the order of initial alpha and beta


### PR DESCRIPTION
The computation of the variational lower bound to the log-likelihood follows Hoffman & Blei. As in our model beta is fixed, we remove all variational terms to bound beta.

Reference
Hoffman, Blei, Bach, Online Learning for Latent Dirichlet Allocation, 2010.