### PR TITLE
Refactoring of non-sketching based code and M1 calculation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ val lda = new TensorLDASketch(
   dimK = params.k,
   alpha0 = params.topicConcentration,
   sketcher = sketcher,
-  idfLowerBound = value,                     // optional, default: 1.0
-  m2ConditionNumberUB = value,               // optional, default: infinity
-  maxIterations = 200,                       // optional, default: 200
-  randomisedSVD = true                       // optional, default: true
-)(tolerance = params.tolerance)              // optional, default: 1e-9
+  idfLowerBound = value,            // optional, default: 1.0
+  m2ConditionNumberUB = value,      // optional, default: infinity
+  maxIterations = 200,              // optional, default: 200
+  randomisedSVD = true              // optional, default: true
+)(tolerance = params.tolerance)     // optional, default: 1e-9
 
 // Fit against the documents
 // beta is the V-by-k matrix, where V is the vocabulary size, 
 // k is the number of topics. It stores the word distribution 
 // per topic column-wise
 // alpha is the length-k Dirichlet prior for the topic distribution
-// eigvecM2 is the V-by-k matrix of the top k eigenvectors of M2
-// eigvalM2 is the length-k vector of the top k eigenvalues of M2
+// eigvecM2 is the V-by-k matrix for the top k eigenvectors of M2
+// eigvalM2 is the length-k vector for the top k eigenvalues of M2
 val (beta: DenseMatrix[Double], alpha: DenseVector[Double], eigvecM2: DenseMatrix[Double], eigvalM2: DenseVector[Double]) = lda.fit(documents)
 ```
 
@@ -110,20 +110,40 @@ import breeze.linalg._
 val lda = new TensorLDA(
   dimK = params.k,
   alpha0 = params.topicConcentration,
-  maxIterations = params.maxIterations,  // optional, default 200
-  tolerance = params.tolerance           // optional, default 1e-9
-)
-
-// If we want to only work on terms with IDF above a certain bound
-// import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
-// val filteredDocs = TextProcessor.filterIDF(documents, <IDF lower bound>)
+  maxIterations = value,            // optional, default: 200
+  idfLowerBound = value,            // optional, default: 1.0
+  m2ConditionNumberUB = value,      // optional, default: infinity
+  randomisedSVD = true              // optional, default: true
+)(tolerance = params.tolerance)     // optional, default: 1e-9
 
 // Fit against the documents
 // beta is the V-by-k matrix, where V is the vocabulary size, 
 // k is the number of topics. It stores the word distribution 
 // per topic column-wise
 // alpha is the length-k Dirichlet prior for the topic distribution
-val (beta: DenseMatrix[Double], alpha: DenseVector[Double]) = lda.fit(documents)
+// eigvecM2 is the V-by-k matrix for the top k eigenvectors of M2
+// eigvalM2 is the length-k vector for the top k eigenvalues of M2
+val (beta: DenseMatrix[Double], alpha: DenseVector[Double], eigvecM2: DenseMatrix[Double], eigvalM2: DenseVector[Double]) = lda.fit(documents)
+```
+
+If one just wants to decompose a 3rd-order symmetric tensor into the sum of rank-1 tensors, we could do
+
+```scala
+import edu.uci.eecs.spectralLDA.algorithm.ALS
+import breeze.linalg._
+
+val als = new ALS(
+  dimK = value,
+  thirdOrderMoments = value,        // k-by-(k*k) matrix for the unfolded 3rd-order symmetric tensor
+  maxIterations = value             // optional, default: 200
+)
+
+// We run ALS to find the best approximating sum of rank-1 tensors such that 
+// $$ M3 = \sum_{i=1}^k\alpha_i\beta_i^{\otimes 3} $$
+
+// beta is the k-by-k matrix with $\beta_i$ as columns
+// alpha is the vector for $(\alpha_1,\ldots,\alpha_k)$
+val (beta: DenseMatrix[Double], alpha: DenseVector[Double]) = als.run
 ```
 
 ### Set up Spark 2.0.0 to use system native BLAS/LAPACK

--- a/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/SpectralLDA.scala
@@ -182,7 +182,7 @@ object SpectralLDA {
     println("Finished reading data.")
 
     println("Start ALS algorithm for tensor decomposition...")
-    val (beta, alpha) = if (params.sketching) {
+    val (beta, alpha, _, _) = if (params.sketching) {
       println("Running tensor decomposition via sketching...")
       val sketcher = TensorSketcher[Double, Double](
         n = Seq(params.k, params.k, params.k),
@@ -198,8 +198,7 @@ object SpectralLDA {
         maxIterations = params.maxIterations,
         randomisedSVD = true
       )(tolerance = params.tolerance)
-      val (beta_, alpha_, _, _) = lda.fit(documents)
-      (beta_, alpha_)
+      lda.fit(documents)
     }
     else {
       val lda = new TensorLDA(

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -31,6 +31,9 @@ class ALS(dimK: Int,
           thirdOrderMoments: DenseMatrix[Double],
           maxIterations: Int = 200)
   extends Serializable {
+  assert(dimK > 0, "The number of topics dimK must be positive.")
+  assert(thirdOrderMoments.rows == dimK && thirdOrderMoments.cols == dimK * dimK,
+    "The thirdOrderMoments must be dimK-by-(dimK * dimK) unfolded matrix")
 
   /** Run Alternating Least Squares (ALS)
     *

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -12,7 +12,7 @@ import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 
 /** Tensor decomposition by Alternating Least Square (ALS)
   *
-  * Suppose dimK-by-dimK-by-dimK tensor T can be decomposed as sum of rank-1 tensors
+  * Suppose dimK-by-dimK-by-dimK symmetric tensor T can be decomposed as sum of rank-1 tensors
   *
   * $$ T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i $$
   *
@@ -24,7 +24,8 @@ import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
   * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
   *
   * @param dimK               tensor T is of shape dimK-by-dimK-by-dimK
-  * @param thirdOrderMoments  3rd-order moments i.e. $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
+  * @param thirdOrderMoments  dimK-by-(dimK*dimK) matrix for the unfolded 3rd-order moments
+  *                           $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
   * @param maxIterations      max iterations for the ALS algorithm
   */
 class ALS(dimK: Int,

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -10,11 +10,36 @@ import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, TensorOps}
 import breeze.linalg.{*, DenseMatrix, DenseVector, norm, max, min}
 import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 
+/** Tensor decomposition by Alternating Least Square (ALS)
+  *
+  * Suppose dimK-by-dimK-by-dimK tensor T can be decomposed as sum of rank-1 tensors
+  *
+  * $$ T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i $$
+  *
+  * If we pool all \lambda_i in the vector \Lambda, all the column vectors \lambda_i a_i in A,
+  * b_i in B, c_i in C, then
+  *
+  * $$ T^{1} = A \diag(\Lambda)(C \khatri-rao product B)^{\top} $$
+  *
+  * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
+  *
+  * @param dimK               tensor T is of shape dimK-by-dimK-by-dimK
+  * @param thirdOrderMoments  3rd-order moments i.e. $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
+  * @param maxIterations      max iterations for the ALS algorithm
+  */
 class ALS(dimK: Int,
           thirdOrderMoments: DenseMatrix[Double],
           maxIterations: Int = 200)
   extends Serializable {
 
+  /** Run Alternating Least Squares (ALS)
+    *
+    * Compute the best approximating rank-$k$ tensor $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
+    *
+    * @param randBasis   default random seed
+    * @return            dimK-by-dimK matrix with all the $beta_i$ as columns,
+    *                    length-dimK vector for all the eigenvalues
+    */
   def run(implicit randBasis: RandBasis = Rand)
      : (DenseMatrix[Double], DenseVector[Double])={
     val gaussian = Gaussian(mu = 0.0, sigma = 1.0)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -5,8 +5,8 @@ package edu.uci.eecs.spectralLDA.algorithm
   * Alternating Least Square algorithm is implemented.
   */
 import breeze.linalg.qr.QR
-import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, NonNegativeAdjustment}
-import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, pinv, qr, sum}
+import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, TensorOps, NonNegativeAdjustment}
+import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, qr, sum}
 import breeze.signal.{fourierTr, iFourierTr}
 import breeze.math.Complex
 import breeze.numerics._
@@ -14,6 +14,7 @@ import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
 import breeze.stats.median
 import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
 
+import scalaxy.loops._
 import scala.language.postfixOps
 
 /** Sketched tensor decomposition by Alternating Least Square (ALS)
@@ -86,7 +87,7 @@ class ALSSketch(dimK: Int,
                                  sketcher: TensorSketcher[Double, Double])
           : DenseMatrix[Double] = {
     // pinv((C^T C) :* (B^T B))
-    val Inverted: DenseMatrix[Double] = AlgebraUtil.to_invert(C, B)
+    val Inverted: DenseMatrix[Double] = TensorOps.to_invert(C, B)
 
     // T(C katri-rao dot B)
     val TIBC: DenseMatrix[Double] = TensorSketchOps.TIUV(fft_sketch_T, B, C, sketcher)
@@ -235,7 +236,7 @@ private[algorithm] object TensorSketchOps {
       && sketcher.n(0) == U.rows)
 
     val result: DenseMatrix[Double] = DenseMatrix.zeros[Double](U.rows, U.cols)
-    for (j <- 0 until U.cols) {
+    for (j <- 0 until U.cols optimized) {
       result(::, j) := TIuv(fft_sketch_T, U(::, j), V(::, j), sketcher)
     }
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -21,11 +21,12 @@ import scala.language.postfixOps
   *
   * Suppose dimK-by-dimK-by-dimK tensor T can be decomposed as sum of rank-1 tensors
   *
-  *    T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i
+  * $$ T = \sum_{i=1}^{dimK} \lambda_i a_i\otimes b_i\otimes c_i $$
   *
-  * If we pool all the column vectors \lambda_i a_i in A, b_i in B, c_i in C, then
+  * If we pool all \lambda_i in the vector \Lambda, all the column vectors \lambda_i a_i in A,
+  * b_i in B, c_i in C, then
   *
-  *    T^{1} = A (C \khatri-rao product B)^{\top}
+  * $$ T^{1} = A \diag(\Lambda)(C \khatri-rao product B)^{\top} $$
   *
   * where T^{1} is a dimK-by-(dimK^2) matrix for the unfolded T.
   *

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALSSketch.scala
@@ -40,6 +40,9 @@ class ALSSketch(dimK: Int,
                 sketcher: TensorSketcher[Double, Double],
                 maxIterations: Int = 200
                 ) extends Serializable {
+  assert(sketcher.n forall { _ == dimK }, s"The sketcher must work on symmetric tensors of shape ($dimK, ..., $dimK).")
+  assert(sketcher.B == fft_sketch_T.rows && sketcher.b == fft_sketch_T.cols,
+    s"fft_sketch_T must be of shape ${sketcher.B}-by-${sketcher.b} as sketcher.B = ${sketcher.B}, sketcher.b = ${sketcher.b}")
 
   def run(implicit randBasis: RandBasis = Rand)
         : (DenseMatrix[Double], DenseVector[Double]) = {

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -26,7 +26,6 @@ class TensorLDA(dimK: Int,
     val cumulant: DataCumulant = DataCumulant.getDataCumulant(
       dimK,
       alpha0,
-      tolerance,
       documents,
       idfLowerBound,
       m2ConditionNumberUB

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -6,27 +6,67 @@ package edu.uci.eecs.spectralLDA.algorithm
  * Created by Furong Huang on 11/2/15.
  */
 import edu.uci.eecs.spectralLDA.datamoments.DataCumulant
-import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, sum}
+import breeze.linalg.{DenseMatrix, DenseVector, SparseVector, argtopk, diag, max, min}
+import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
+import edu.uci.eecs.spectralLDA.utils.NonNegativeAdjustment
 import org.apache.spark.rdd.RDD
 
 class TensorLDA(dimK: Int,
                 alpha0: Double,
                 maxIterations: Int = 200,
-                tolerance: Double = 1e-9)
+                idfLowerBound: Double = 1.0,
+                m2ConditionNumberUB: Double = Double.PositiveInfinity)
+               (implicit tolerance: Double = 1e-9)
                 extends Serializable {
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)
-          : (DenseMatrix[Double], DenseVector[Double]) = {
-    val myData: DataCumulant = DataCumulant.getDataCumulant(
-      dimK, alpha0,
+          : (DenseMatrix[Double], DenseVector[Double], DenseMatrix[Double], DenseVector[Double]) = {
+    val cumulant: DataCumulant = DataCumulant.getDataCumulant(
+      dimK,
+      alpha0,
       tolerance,
-      documents
+      documents,
+      idfLowerBound,
+      m2ConditionNumberUB
     )
 
-    val myALS: ALS = new ALS(dimK, myData)
-    myALS.run(documents.sparkContext, maxIterations)
+    val myALS: ALS = new ALS(
+      dimK,
+      cumulant.thirdOrderMoments,
+      maxIterations = maxIterations
+    )
+
+    val (nu: DenseMatrix[Double], lambda: DenseVector[Double]) = myALS.run
+
+    // unwhiten the results
+    // unwhitening matrix: $(W^T)^{-1}=U\Sigma^{1/2}$
+    val unwhiteningMatrix = cumulant.eigenVectorsM2 * diag(sqrt(cumulant.eigenValuesM2))
+
+    val alphaUnordered: DenseVector[Double] = lambda.map(x => scala.math.pow(x, -2))
+    val topicWordMatrixUnordered: DenseMatrix[Double] = unwhiteningMatrix * nu * diag(lambda)
+
+    // re-arrange alpha and topicWordMatrix in descending order of alpha
+    val idx = argtopk(alphaUnordered, dimK)
+    val alpha = alphaUnordered(idx).toDenseVector
+    val topicWordMatrix = topicWordMatrixUnordered(::, idx).toDenseMatrix
+
+    // Diagnostic information: the ratio of the maximum to the minimum of the
+    // top k eigenvalues of shifted M2
+    //
+    // If it's too large (>10), the algorithm may not be able to output reasonable results.
+    // It could be due to some very frequent (low IDF) words or that we specified dimK
+    // larger than the rank of the shifted M2.
+    val m2ConditionNumber = max(cumulant.eigenValuesM2) / min(cumulant.eigenValuesM2)
+    println(s"Shifted M2 top $dimK eigenvalues: ${cumulant.eigenValuesM2}")
+    println(s"Shifted M2 condition number: $m2ConditionNumber")
+    println("If the condition number is too large (e.g. >10), the algorithm may not be able to " +
+      "output reasonable results. It could be due to the existence of very frequent words " +
+      "across the documents or that the specified k is larger than the true number of topics.")
+
+    (NonNegativeAdjustment.simplexProj_Matrix(topicWordMatrix), alpha,
+      cumulant.eigenVectorsM2, cumulant.eigenValuesM2)
   }
 
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -16,7 +16,8 @@ class TensorLDA(dimK: Int,
                 alpha0: Double,
                 maxIterations: Int = 200,
                 idfLowerBound: Double = 1.0,
-                m2ConditionNumberUB: Double = Double.PositiveInfinity)
+                m2ConditionNumberUB: Double = Double.PositiveInfinity,
+                randomisedSVD: Boolean = true)
                (implicit tolerance: Double = 1e-9)
                 extends Serializable {
   assert(dimK > 0, "The number of topics dimK must be positive.")
@@ -31,7 +32,8 @@ class TensorLDA(dimK: Int,
       alpha0,
       documents,
       idfLowerBound,
-      m2ConditionNumberUB
+      m2ConditionNumberUB,
+      randomisedSVD = randomisedSVD
     )
 
     val myALS: ALS = new ALS(

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -19,6 +19,9 @@ class TensorLDA(dimK: Int,
                 m2ConditionNumberUB: Double = Double.PositiveInfinity)
                (implicit tolerance: Double = 1e-9)
                 extends Serializable {
+  assert(dimK > 0, "The number of topics dimK must be positive.")
+  assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+  assert(maxIterations > 0, "The number of iterations for ALS must be positive.")
 
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -19,14 +19,10 @@ class TensorLDA(dimK: Int,
   def fit(documents: RDD[(Long, SparseVector[Double])])
          (implicit randBasis: RandBasis = Rand)
           : (DenseMatrix[Double], DenseVector[Double]) = {
-    val documents_ = documents map {
-      case (id, wc) => (id, sum(wc), wc)
-    }
-
     val myData: DataCumulant = DataCumulant.getDataCumulant(
       dimK, alpha0,
       tolerance,
-      documents_
+      documents
     )
 
     val myALS: ALS = new ALS(dimK, myData)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -10,14 +10,41 @@ import breeze.linalg._
 import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
 import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
-import edu.uci.eecs.spectralLDA.utils
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
 
 import scalaxy.loops._
 
-
+/** Data cumulant
+  *
+  * Let the truncated eigendecomposition of the shifted M2 be
+  *
+  * $$M2 = U\Sigma U^T,$$
+  *
+  * where $M2\in\mathsf{R}^{V\times V}$, $U\in\mathsf{R}^{V\times k}$,
+  * $\Sigma\in\mathsf{R}^{k\times k}$, $V$ is the vocabulary size,
+  * $k$ is the number of topics, $k<V$.
+  *
+  * If we denote $W=U\Sigma^{-1/2}$, then $W^T M2 W\approx I$. We call $W$ the whitening matrix.
+  *
+  * $W$ could be used to whiten the shifted M3,
+  *
+  * $$ \frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)
+  *       = \sum_{i=1}^k\alpha_i(W^T\mu_i)^{\otimes 3}
+  *       = \sum_{i=1}^k\alpha_i^{-1/2}(W^T\alpha_i^{1/2}\mu_i)^{\otimes 3} $$
+  *
+  * Note $W^T\alpha_i^{1/2}\mu_i$ are orthonormal, for all $1\le i\le k$.
+  *
+  * @param thirdOrderMoments Scaled whitened M3, precisely,
+  *                            $\frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)$
+  * @param eigenVectorsM2   V-by-k top eigenvectors of shifted M2, stored column-wise
+  * @param eigenValuesM2    length-k top eigenvalues of shifted M2
+  *
+  * REFERENCES
+  * [Wang2015] Wang Y et al, Fast and Guaranteed Tensor Decomposition via Sketching, 2015,
+  *            http://arxiv.org/abs/1506.04448
+  *
+  */
 case class DataCumulant(thirdOrderMoments: DenseMatrix[Double],
                         eigenVectorsM2: DenseMatrix[Double],
                         eigenValuesM2: DenseVector[Double])

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -13,7 +13,6 @@ import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
 
-import scalaxy.loops._
 
 /** Data cumulant
   *
@@ -81,12 +80,19 @@ object DataCumulant {
     val numDocs = validDocuments.count()
 
     println("Start calculating first order moments...")
-    val firstOrderMoments: DenseVector[Double] = validDocuments
-      .map {
-        case (_, length, vec) => vec / length.toDouble
+    val (m1Index: Array[Int], m1Value: Array[Double]) = validDocuments
+      .flatMap {
+        case (_, length, vec) =>
+          val termDistribution: SparseVector[Double] = vec / length.toDouble
+          termDistribution.activeIterator.toSeq
       }
-      .reduce(_ + _)
-      .map(_ / numDocs.toDouble).toDenseVector
+      .reduceByKey(_ + _)
+      .mapValues(_ / numDocs.toDouble)
+      .collect
+      .sorted
+      .unzip
+    val firstOrderMoments = new SparseVector[Double](m1Index, m1Value, dimVocab).toDenseVector
+
     // Zero out the terms with low IDF
     firstOrderMoments(termsLowIDF) := 0.0
     println("Finished calculating first order moments.")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -5,18 +5,22 @@ package edu.uci.eecs.spectralLDA.datamoments
  * Created by Furong Huang on 11/2/15.
  */
 
-import edu.uci.eecs.spectralLDA.utils.RandNLA
+import edu.uci.eecs.spectralLDA.utils.{RandNLA, TensorOps}
 import breeze.linalg._
+import breeze.numerics._
 import breeze.stats.distributions.{Rand, RandBasis}
+import edu.uci.eecs.spectralLDA.textprocessing.TextProcessor
+import edu.uci.eecs.spectralLDA.utils
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
 
-import scala.collection.mutable
 import scalaxy.loops._
-import scala.language.postfixOps
 
-case class DataCumulant(thirdOrderMoments: DenseMatrix[Double], unwhiteningMatrix: DenseMatrix[Double])
+
+case class DataCumulant(thirdOrderMoments: DenseMatrix[Double],
+                        eigenVectorsM2: DenseMatrix[Double],
+                        eigenValuesM2: DenseVector[Double])
   extends Serializable
 
 
@@ -24,117 +28,223 @@ object DataCumulant {
   def getDataCumulant(dimK: Int,
                       alpha0: Double,
                       tolerance: Double,
-                      documents: RDD[(Long, Double, SparseVector[Double])])
+                      documents: RDD[(Long, SparseVector[Double])],
+                      idfLowerBound: Double = 1.0,
+                      m2ConditionNumberUB: Double = Double.PositiveInfinity)
                      (implicit randBasis: RandBasis = Rand)
         : DataCumulant = {
     val sc: SparkContext = documents.sparkContext
-    val dimVocab = documents.take(1)(0)._3.length
-    val numDocs = documents.count()
+
+    val idf: DenseVector[Double] = TextProcessor.inverseDocumentFrequency(documents)
+    val termsLowIDF: Seq[Int] = idf.findAll(_ <= idfLowerBound - 1e-12)
+
+    val validDocuments = documents
+      .map {
+        case (id, wc) => (id, sum(wc), wc)
+      }
+      .filter {
+        case (_, len, _) => len >= 3
+      }
+    validDocuments.cache()
+
+    val dimVocab = validDocuments.map(_._3.length).take(1)(0)
+    val numDocs = validDocuments.count()
 
     println("Start calculating first order moments...")
-    val M1: DenseVector[Double] = documents map {
-      case (_, length, vec) => update_firstOrderMoments(dimVocab, vec.toDenseVector, length)
-    } reduce (_ + _)
-
-    val firstOrderMoments: DenseVector[Double] = M1 / numDocs.toDouble
+    val firstOrderMoments: DenseVector[Double] = validDocuments
+      .map {
+        case (_, length, vec) => vec / length.toDouble
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble).toDenseVector
+    // Zero out the terms with low IDF
+    firstOrderMoments(termsLowIDF) := 0.0
     println("Finished calculating first order moments.")
 
     println("Start calculating second order moments...")
-    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) = RandNLA.whiten2(alpha0,
-      dimVocab, dimK, numDocs, firstOrderMoments, documents)
+    val (eigenVectors: DenseMatrix[Double], eigenValues: DenseVector[Double]) =
+      RandNLA.whiten2(
+        alpha0,
+        dimVocab,
+        dimK,
+        numDocs,
+        firstOrderMoments,
+        validDocuments,
+        termsLowIDF
+      )
     println("Finished calculating second order moments and whitening matrix.")
 
-    println("Start whitening data with dimensionality reduction...")
-    val whitenedData: RDD[(DenseVector[Double], Double)] = documents.map {
-      case (_, length, vec) => (project(dimVocab, dimK, alpha0, eigenValues, eigenVectors, vec)(tolerance), length)
+    val m2ConditionNumber: Double = max(eigenValues) / min(eigenValues)
+    if (m2ConditionNumber > m2ConditionNumberUB) {
+      println(s"ERROR: Shifted M2 top $dimK eigenvalues: $eigenValues")
+      println(s"ERROR: Shifted M2 condition number: $m2ConditionNumber > UB $m2ConditionNumberUB")
+      sys.exit(2)
     }
-    val firstOrderMoments_whitened: DenseVector[Double] = whitenedData
-      .map(x => x._1 / x._2)
-      .reduce((a, b) => a :+ b)
-      .map(x => x / numDocs.toDouble)
+
+    println("Start whitening data with dimensionality reduction...")
+    val W: DenseMatrix[Double] = eigenVectors * diag(eigenValues map { x => 1 / (sqrt(x) + tolerance) })
     println("Finished whitening data.")
 
+    // We computing separately the first order, second order, 3rd order terms in Eq (25) (26)
+    // in [Wang2015]. For the 2nd order, 3rd order terms, We'd achieve maximum performance with
+    // reduceByKey() of w_i, 1\le i\le V, the rows of the whitening matrix W.
     println("Start calculating third order moments...")
-    val Ta: DenseMatrix[Double] = whitenedData map {
-      case (vec, len) => update_thirdOrderMoments(
-        dimK, alpha0,
-        firstOrderMoments_whitened,
-        vec, len)
-    } reduce(_ + _)
+    val firstOrderMoments_whitened = W.t * firstOrderMoments
+    val broadcasted_W = sc.broadcast[DenseMatrix[Double]](W)
 
-    val alpha0sq: Double = alpha0 * alpha0
-    val Ta_shift = DenseMatrix.zeros[Double](dimK, dimK * dimK)
-    for (id_i <- 0 until dimK optimized) {
-      for (id_j <- 0 until dimK optimized) {
-        for (id_l <- 0 until dimK optimized) {
-          Ta_shift(id_i, id_j * dimK + id_l) += (alpha0sq * firstOrderMoments_whitened(id_i)
-            * firstOrderMoments_whitened(id_j) * firstOrderMoments_whitened(id_l))
-        }
+    // First order terms: p^{\otimes 3}, p\otimes p\otimes q, p\otimes q\otimes p,
+    // q\otimes p\otimes p
+    val m3FirstOrderPart = validDocuments
+      .map {
+        case (_, len, vec) => whitenedM3FirstOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
       }
-    }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // Second order terms: all terms as w_i\otimes w_i\otimes p, w_i\otimes w_i\otimes q,
+    // 1\le i\le V and their permutations
+    val m3SecondOrderPart = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3SecondOrderTerms(
+          alpha0,
+          broadcasted_W.value,
+          firstOrderMoments_whitened,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, x: DenseVector[Double]) => computeSecondOrderTerms(
+          i, x,
+          broadcasted_W.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // Third order terms: all terms w_i^{\otimes 3}, 1\le i\le V
+    val m3ThirdOrderPart = validDocuments
+      .flatMap {
+        case (_, len, vec) => whitenedM3ThirdOrderTerms(
+          alpha0,
+          vec, len
+        )
+      }
+      .reduceByKey(_ + _)
+      .map {
+        case (i: Int, p: Double) => computeThirdOrderTerms(
+          i, p,
+          broadcasted_W.value
+        )
+      }
+      .reduce(_ + _)
+      .map(_ / numDocs.toDouble)
+
+    // sketch of q=W^T M1
+    val q_otimes_3 = 2 * alpha0 * alpha0 / ((alpha0 + 1) * (alpha0 + 2)) * TensorOps.makeRankOneTensor3d(
+      firstOrderMoments_whitened, firstOrderMoments_whitened, firstOrderMoments_whitened
+    )
+
+    broadcasted_W.unpersist()
+
+    val whitenedM3 = m3FirstOrderPart + m3SecondOrderPart + m3ThirdOrderPart + q_otimes_3
     println("Finished calculating third order moments.")
 
-    val thirdOrderMoments = Ta / numDocs.toDouble + Ta_shift
-    val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
+    // val unwhiteningMatrix: breeze.linalg.DenseMatrix[Double] = eigenVectors * breeze.linalg.diag(eigenValues.map(x => scala.math.sqrt(x)))
 
-    new DataCumulant(thirdOrderMoments, unwhiteningMatrix)
+    new DataCumulant(
+      whitenedM3 * alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0,
+      eigenVectors,
+      eigenValues
+    )
   }
 
+  private def whitenedM3FirstOrderTerms(alpha0: Double,
+                                        W: DenseMatrix[Double],
+                                        q: DenseVector[Double],
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : DenseMatrix[Double] = {
+    // $p=W^T n$, where n is the original word count vector
+    val p: DenseVector[Double] = W.t * n
 
-  private def update_firstOrderMoments(dim: Int, Wc: breeze.linalg.DenseVector[Double], len: Double) = {
-    val M1: DenseVector[Double] = Wc / len
-    M1
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
+
+    val s1 = TensorOps.makeRankOneTensor3d(p, p, p)
+    val s2 = TensorOps.makeRankOneTensor3d(p, p, q)
+    val s3 = TensorOps.makeRankOneTensor3d(p, q, p)
+    val s4 = TensorOps.makeRankOneTensor3d(q, p, p)
+
+    coeff1 * s1 - coeff2 * h1 * (s2 + s3 + s4)
   }
 
-  private def update_thirdOrderMoments(dimK: Int, alpha0: Double, m1: DenseVector[Double], Wc: DenseVector[Double], len: Double): DenseMatrix[Double] = {
-    val len_calibrated: Double = math.max(len, 3.0)
+  private def whitenedM3SecondOrderTerms(alpha0: Double,
+                                         W: DenseMatrix[Double],
+                                         q: DenseVector[Double],
+                                         n: SparseVector[Double],
+                                         len: Double)
+  : Seq[(Int, DenseVector[Double])] = {
+    val p: DenseVector[Double] = W.t * n
 
-    val scale3fac: Double = (alpha0 + 1.0) * (alpha0 + 2.0) / (2.0 * len_calibrated * (len_calibrated - 1.0) * (len_calibrated - 2.0))
-    val scale2fac: Double = alpha0 * (alpha0 + 1.0) / (2.0 * len_calibrated * (len_calibrated - 1.0))
-    val Ta = breeze.linalg.DenseMatrix.zeros[Double](dimK, dimK * dimK)
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
 
-    import scalaxy.loops._
-    import scala.language.postfixOps
-    for (i <- 0 until dimK optimized) {
-      for (j <- 0 until dimK optimized) {
-        for (l <- 0 until dimK optimized) {
-          Ta(i, dimK * j + l) += scale3fac * Wc(i) * Wc(j) * Wc(l)
-
-          Ta(i, dimK * j + l) -= scale2fac * Wc(i) * Wc(j) * m1(l)
-          Ta(i, dimK * j + l) -= scale2fac * Wc(i) * m1(j) * Wc(l)
-          Ta(i, dimK * j + l) -= scale2fac * m1(i) * Wc(j) * Wc(l)
-        }
-        Ta(i, dimK * i + j) -= scale3fac * Wc(i) * Wc(j)
-        Ta(i, dimK * j + i) -= scale3fac * Wc(i) * Wc(j)
-        Ta(i, dimK * j + j) -= scale3fac * Wc(i) * Wc(j)
-
-        Ta(i, dimK * i + j) += scale2fac * Wc(i) * m1(j)
-        Ta(i, dimK * j + i) += scale2fac * Wc(i) * m1(j)
-        Ta(i, dimK * j + j) += scale2fac * m1(i) * Wc(j)
-      }
-      Ta(i, dimK * i + i) += 2.0 * scale3fac * Wc(i)
+    var seqTerms = Seq[(Int, DenseVector[Double])]()
+    for ((wc_index, wc_value) <- n.activeIterator) {
+      seqTerms ++= Seq(
+        (wc_index, -coeff1 * wc_value * p),
+        (wc_index, coeff2 * h1 * wc_value * q)
+      )
     }
-    Ta
+
+    seqTerms
   }
 
-  private def project(dimVocab: Int, dimK: Int, alpha0: Double,
-                      eigenValues: breeze.linalg.DenseVector[Double],
-                      eigenVectors: breeze.linalg.DenseMatrix[Double],
-                      Wc: breeze.linalg.SparseVector[Double])
-                     (implicit tolerance: Double)
-  : breeze.linalg.DenseVector[Double] = {
-    var offset = 0
-    val result = breeze.linalg.DenseVector.zeros[Double](dimK)
-    while (offset < Wc.activeSize) {
-      val token: Int = Wc.indexAt(offset)
-      val count: Double = Wc.valueAt(offset)
-      // val S_row = S(token,::)
+  private def whitenedM3ThirdOrderTerms(alpha0: Double,
+                                        n: SparseVector[Double],
+                                        len: Double)
+  : Seq[(Int, Double)] = {
+    val coeff1 = 1.0 / (len * (len - 1) * (len - 2))
+    val coeff2 = 1.0 / (len * (len - 1))
+    val h1 = alpha0 / (alpha0 + 2)
 
-      result += eigenVectors(token, ::).t.map(x => x * count)
-
-      offset += 1
+    var seqTerms = Seq[(Int, Double)]()
+    for ((wc_index, wc_value) <- n.activeIterator) {
+      seqTerms :+= (wc_index, 2 * coeff1 * wc_value)
     }
-    val whitenedData = result :/ eigenValues.map(x => math.sqrt(x) + tolerance)
-    whitenedData
+
+    seqTerms
+  }
+
+  private def computeSecondOrderTerms(i: Int,
+                                      x: DenseVector[Double],
+                                      W: DenseMatrix[Double])
+      : DenseMatrix[Double] = {
+    val w: DenseVector[Double] = W(i, ::).t
+
+    val prod1 = TensorOps.makeRankOneTensor3d(w, w, x)
+    val prod2 = TensorOps.makeRankOneTensor3d(w, x, w)
+    val prod3 = TensorOps.makeRankOneTensor3d(x, w, w)
+
+    prod1 + prod2 + prod3
+  }
+
+  private def computeThirdOrderTerms(i: Int,
+                                     p: Double,
+                                     W: DenseMatrix[Double])
+      : DenseMatrix[Double] = {
+    val w: DenseVector[Double] = W(i, ::).t
+
+    val z = TensorOps.makeRankOneTensor3d(w, w, w)
+
+    z * p
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulant.scala
@@ -60,6 +60,9 @@ object DataCumulant {
                       randomisedSVD: Boolean = true)
                      (implicit randBasis: RandBasis = Rand, tolerance: Double = 1e-9)
         : DataCumulant = {
+    assert(dimK > 0, "The number of topics dimK must be positive.")
+    assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+
     val sc: SparkContext = documents.sparkContext
 
     val idf: DenseVector[Double] = TextProcessor.inverseDocumentFrequency(documents)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -64,6 +64,10 @@ object DataCumulantSketch {
                       randomisedSVD: Boolean = true)
                      (implicit tolerance: Double = 1e-9, randBasis: RandBasis = Rand)
   : DataCumulantSketch = {
+    assert(dimK > 0, "The number of topics dimK must be positive.")
+    assert(alpha0 > 0, "The topic concentration alpha0 must be positive.")
+    assert(sketcher.n forall { _ == dimK }, s"The sketcher must work on symmetric tensors of shape ($dimK, ..., $dimK).")
+
     val sc: SparkContext = documents.sparkContext
 
     val idf: DenseVector[Double] = TextProcessor.inverseDocumentFrequency(documents)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantSketch.scala
@@ -20,15 +20,26 @@ import scala.language.postfixOps
 
 /** Sketch of data cumulant
   *
-  * Let the truncated eigendecomposition of $M2$ be $U\Sigma U^T$, $M2\in\mathsf{R}^{V\times V}$,
-  * $U\in\mathsf{R}^{V\times k}$, $\Sigma\in\mathsf{R}^{k\times k}$, where $V$ is the vocabulary size,
+  * Let the truncated eigendecomposition of the shifted M2 be
+  *
+  * $$M2 = U\Sigma U^T,$$
+  *
+  * where $M2\in\mathsf{R}^{V\times V}$, $U\in\mathsf{R}^{V\times k}$,
+  * $\Sigma\in\mathsf{R}^{k\times k}$, $V$ is the vocabulary size,
   * $k$ is the number of topics, $k<V$.
   *
   * If we denote $W=U\Sigma^{-1/2}$, then $W^T M2 W\approx I$. We call $W$ the whitening matrix.
   *
-  * @param fftSketchWhitenedM3 FFT of the sketch of whitened M3, multiplied by a coefficient
-  *                                i.e \frac{(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)
-  *                                      = \sum_{i=1}^k\frac{\alpha_i}{\alpha_0}(W^T\mu_i)^{\otimes 3}
+  * $W$ could be used to whiten the shifted M3,
+  *
+  * $$ \frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)
+  *       = \sum_{i=1}^k\alpha_i(W^T\mu_i)^{\otimes 3}
+  *       = \sum_{i=1}^k\alpha_i^{-1/2}(W^T\alpha_i^{1/2}\mu_i)^{\otimes 3} $$
+  *
+  * Note $W^T\alpha_i^{1/2}\mu_i$ are orthonormal, for all $1\le i\le k$.
+  *
+  * @param fftSketchWhitenedM3 FFT of the sketch of scaled whitened M3, precisely,
+  *                            $\frac{\alpha_0(\alpha_0+1)(\alpha_0+2)}{2} M3(W^T,W^T,W^T)$
   * @param eigenVectorsM2   V-by-k top eigenvectors of shifted M2, stored column-wise
   * @param eigenValuesM2    length-k top eigenvalues of shifted M2
   *

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/AlgebraUtil.scala
@@ -6,20 +6,10 @@ package edu.uci.eecs.spectralLDA.utils
  */
 
 import breeze.linalg._
-import breeze.numerics._
-import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
-
 import scalaxy.loops._
 import scala.language.postfixOps
 
 object AlgebraUtil {
-
-  def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
-    val ctc: DenseMatrix[Double] = c.t * c
-    val btb: DenseMatrix[Double] = b.t * b
-    val to_be_inverted: DenseMatrix[Double] = ctc :* btb
-    breeze.linalg.pinv(to_be_inverted)
-  }
 
   def matrixNormalization(B: DenseMatrix[Double]): DenseMatrix[Double] = {
     val A: DenseMatrix[Double] = B.copy
@@ -29,48 +19,6 @@ object AlgebraUtil {
       A(::, i) :/= colNorms(i)
     }
     A
-  }
-
-  def KhatrioRao(A: DenseVector[Double], B: DenseVector[Double]): DenseVector[Double] = {
-    val Out: DenseMatrix[Double] = B * A.t
-    Out.flatten()
-  }
-
-  def KhatrioRao(A: DenseMatrix[Double], B: DenseMatrix[Double]): DenseMatrix[Double] = {
-    assert(B.cols == A.cols)
-    val Out = DenseMatrix.zeros[Double](B.rows * A.rows, A.cols)
-    for (i <- 0 until A.cols optimized) {
-      Out(::, i) := KhatrioRao(A(::, i), B(::, i))
-
-    }
-    Out
-  }
-
-
-  def Multip_KhatrioRao(T: DenseVector[Double], C: DenseVector[Double], B: DenseVector[Double]): Double = {
-    val longvec: DenseVector[Double] = KhatrioRao(C, B)
-    T dot longvec
-  }
-
-  def Multip_KhatrioRao(T: DenseVector[Double], C: DenseMatrix[Double], B: DenseMatrix[Double]): DenseVector[Double] = {
-    assert(B.cols == C.cols)
-    val Out = DenseVector.zeros[Double](C.cols)
-    for (i <- 0 until C.cols optimized) {
-      Out(i) = Multip_KhatrioRao(T, C(::, i), B(::, i))
-
-    }
-    Out
-  }
-
-
-  def Multip_KhatrioRao(T: DenseMatrix[Double], C: DenseMatrix[Double], B: DenseMatrix[Double]): DenseMatrix[Double] = {
-    assert(B.cols == C.cols)
-    val Out = DenseMatrix.zeros[Double](C.cols, T.rows)
-    for (i <- 0 until T.rows optimized) {
-      val thisRowOfT: DenseVector[Double] = T(i, ::).t
-      Out(::, i) := Multip_KhatrioRao(thisRowOfT, C, B)
-    }
-    Out.t
   }
 
   def isConverged(oldA: DenseMatrix[Double], newA: DenseMatrix[Double])

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -5,7 +5,7 @@ import breeze.math.{Complex, Semiring}
 import breeze.storage.Zero
 
 import scala.reflect.ClassTag
-
+import scalaxy.loops._
 
 object TensorOps {
   def matrixNorm(m: DenseMatrix[Complex]): Double = {
@@ -34,6 +34,29 @@ object TensorOps {
       t(Seq(i, j, k)) = g(i, k * n(1) + j)
     }
     t
+  }
+
+  /** makes 3rd-order rank-1 tensor $$x\otimes y\otimes z$$, returns the unfolded version */
+  def makeRankOneTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+      (x: DenseVector[V], y: DenseVector[V], z: DenseVector[V]): DenseMatrix[V] = {
+    val d1 = x.length
+    val d2 = y.length
+    val d3 = z.length
+
+    val result = DenseMatrix.zeros[V](d1, d2 * d3)
+
+    val evV = implicitly[Numeric[V]]
+    import evV._
+
+    for (i <- 0 until d1 optimized) {
+      for (j <- 0 until d2 optimized) {
+        for (k <- 0 until d3 optimized) {
+          result(i, k * d2 + j) = x(d1) * y(d2) * z(d3)
+        }
+      }
+    }
+
+    result
   }
 
   /** Khatri-Rao product */

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -6,6 +6,7 @@ import breeze.storage.Zero
 
 import scala.reflect.ClassTag
 import scalaxy.loops._
+import scala.language.postfixOps
 
 object TensorOps {
   def matrixNorm(m: DenseMatrix[Complex]): Double = {
@@ -78,6 +79,13 @@ object TensorOps {
       result(::, i) := krprod[V](A(::, i), B(::, i))
     }
     result
+  }
+
+  def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val ctc: DenseMatrix[Double] = c.t * c
+    val btb: DenseMatrix[Double] = b.t * b
+    val to_be_inverted: DenseMatrix[Double] = ctc :* btb
+    breeze.linalg.pinv(to_be_inverted)
   }
 
   /** tensor product v * v.t given sparse vector v */

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -9,14 +9,17 @@ import scalaxy.loops._
 import scala.language.postfixOps
 
 object TensorOps {
+  /** Complex matrix norm */
   def matrixNorm(m: DenseMatrix[Complex]): Double = {
     norm(norm(m(::, *)).toDenseVector)
   }
 
+  /** Double matrix norm */
   def dmatrixNorm(m: DenseMatrix[Double]): Double = {
     norm(norm(m(::, *)).toDenseVector)
   }
 
+  /** Unfold 3rd-order tensor */
   def unfoldTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
         (t: Tensor[Seq[Int], V], n: Seq[Int]): DenseMatrix[V] = {
     assert(n.length == 3)
@@ -27,6 +30,7 @@ object TensorOps {
     m
   }
 
+  /** Build 3rd-order tensor from the unfolded representation */
   def tensor3dFromUnfolded[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
       (g: DenseMatrix[V], n: Seq[Int]): Tensor[Seq[Int], V] = {
     assert(n.length == 3)
@@ -52,7 +56,7 @@ object TensorOps {
     for (i <- 0 until d1 optimized) {
       for (j <- 0 until d2 optimized) {
         for (k <- 0 until d3 optimized) {
-          result(i, k * d2 + j) = x(d1) * y(d2) * z(d3)
+          result(i, k * d2 + j) = x(i) * y(j) * z(k)
         }
       }
     }
@@ -81,6 +85,7 @@ object TensorOps {
     result
   }
 
+  /** Part of the ALS update formula */
   def to_invert(c: DenseMatrix[Double], b: DenseMatrix[Double]): DenseMatrix[Double] = {
     val ctc: DenseMatrix[Double] = c.t * c
     val btb: DenseMatrix[Double] = b.t * b

--- a/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDATest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDATest.scala
@@ -1,0 +1,158 @@
+package edu.uci.eecs.spectralLDA.algorithm
+
+import org.scalatest._
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
+import breeze.linalg._
+import breeze.stats.distributions._
+import edu.uci.eecs.spectralLDA.sketch.TensorSketcher
+import org.apache.commons.math3.random.MersenneTwister
+
+class TensorLDATest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+                     (implicit randBasis: RandBasis = Rand)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+
+  "Simulated LDA" should "be recovered" in {
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](6, 3,
+      Array[Double](0.4, 0.4, 0.05, 0.05, 0.05, 0.05,
+        0.05, 0.05, 0.4, 0.4, 0.05, 0.05,
+        0.05, 0.05, 0.05, 0.05, 0.4, 0.4))
+
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(57175437L)))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 5000,
+      numTokensPerDocument = 100
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val tensorLDA = new TensorLDA(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      maxIterations = 200,
+      randomisedSVD = false
+    )
+
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double], _, _) = tensorLDA.fit(documentsRDD)
+
+    // Rearrange the elements/columns of fitted_alpha and fitted_beta
+    // to the order of initial alpha and beta
+    val idx = argtopk(fitted_alpha, 3)
+    val sorted_beta = fitted_beta(::, idx).toDenseMatrix
+    // if one vector is all negative, multiply it by -1 to turn it positive
+    for (j <- 0 until sorted_beta.cols) {
+      if (max(sorted_beta(::, j)) <= 0.0) {
+        sorted_beta(::, j) :*= -1.0
+      }
+    }
+    val sorted_alpha = fitted_alpha(idx).toDenseVector
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - allTokenDistributions
+    val diff_alpha: DenseVector[Double] = sorted_alpha - alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    info(s"Expecting alpha: $alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+    info(s"Norm of difference alpha: $norm_diff_alpha")
+
+    info(s"Expecting beta:\n$allTokenDistributions")
+    info(s"Obtained beta:\n$sorted_beta")
+    info(s"Norm of difference beta: $norm_diff_beta")
+
+    norm_diff_beta should be <= 0.2
+    norm_diff_alpha should be <= 4.0
+  }
+
+  "Simulated LDA" should "be recovered with randomised SVD" in {
+    implicit val randBasis: RandBasis =
+      new RandBasis(new ThreadLocalRandomGenerator(new MersenneTwister(23476541L)))
+
+    val alpha: DenseVector[Double] = DenseVector[Double](20.0, 10.0, 5.0)
+    val allTokenDistributions: DenseMatrix[Double] = DenseMatrix.rand(100, 3, Uniform(0.0, 1.0))
+    allTokenDistributions(0 until 10, 0) += 3.0
+    allTokenDistributions(10 until 20, 1) += 3.0
+    allTokenDistributions(20 until 30, 2) += 3.0
+
+
+    val s = sum(allTokenDistributions(::, *))
+    val normalisedAllTokenDistributions: DenseMatrix[Double] =
+      allTokenDistributions * diag(1.0 / s.toDenseVector)
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 5000,
+      numTokensPerDocument = 500
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val dimK = 3
+
+    val tensorLDA = new TensorLDA(
+      dimK = dimK,
+      alpha0 = sum(alpha(0 until dimK)),
+      maxIterations = 200,
+      randomisedSVD = true
+    )
+
+    val (fitted_beta: DenseMatrix[Double], fitted_alpha: DenseVector[Double], _, _) = tensorLDA.fit(documentsRDD)
+
+    // Rearrange the elements/columns of fitted_alpha and fitted_beta
+    // to the order of initial alpha and beta
+    val idx = argtopk(fitted_alpha, dimK)
+    val sorted_beta = fitted_beta(::, idx).toDenseMatrix
+    val sorted_alpha = fitted_alpha(idx).toDenseVector
+
+    val expected_alpha = alpha(0 until dimK)
+    val expected_beta = normalisedAllTokenDistributions(::, 0 until dimK)
+
+    val diff_beta: DenseMatrix[Double] = sorted_beta - expected_beta
+    val diff_alpha: DenseVector[Double] = sorted_alpha - expected_alpha
+
+    val norm_diff_beta = norm(norm(diff_beta(::, *)).toDenseVector)
+    val norm_diff_alpha = norm(diff_alpha)
+
+    info(s"Expecting alpha: $expected_alpha")
+    info(s"Obtained alpha: $sorted_alpha")
+    info(s"Norm of difference alpha: $norm_diff_alpha")
+
+    info(s"Expecting beta:\n$expected_beta")
+    info(s"Obtained beta:\n$sorted_beta")
+    info(s"Norm of difference beta: $norm_diff_beta")
+
+    norm_diff_beta should be <= 0.025
+    norm_diff_alpha should be <= 3.5
+  }
+}

--- a/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/datamoments/DataCumulantTest.scala
@@ -1,0 +1,172 @@
+package edu.uci.eecs.spectralLDA.datamoments
+
+import breeze.linalg._
+import breeze.stats.distributions.{Dirichlet, Multinomial}
+import breeze.numerics.sqrt
+import edu.uci.eecs.spectralLDA.utils.TensorOps
+import org.scalatest._
+import org.scalatest.Matchers._
+
+import org.apache.spark.SparkContext
+import edu.uci.eecs.spectralLDA.testharness.Context
+
+class DataCumulantTest extends FlatSpec with Matchers {
+
+  private val sc: SparkContext = Context.getSparkContext
+
+  def simulateLDAData(alpha: DenseVector[Double],
+                      allTokenDistributions: DenseMatrix[Double],
+                      numDocuments: Int,
+                      numTokensPerDocument: Int)
+  : Seq[(Long, SparseVector[Double])] = {
+    assert(alpha.size == allTokenDistributions.cols)
+    val k = alpha.size
+    val V = allTokenDistributions.rows
+
+    // Simulate the word histogram of each document
+    val dirichlet = Dirichlet(alpha)
+    val wordCounts: Seq[(Long, SparseVector[Double])] = for {
+      d <- 0 until numDocuments
+
+      topicDistribution: DenseVector[Double] = dirichlet.sample()
+      tokenDistribution: DenseVector[Double] = allTokenDistributions * topicDistribution
+      tokens = Multinomial(tokenDistribution) sample numTokensPerDocument
+
+      c = SparseVector.zeros[Double](V)
+      tokensCount = tokens foreach { t => c(t) += 1.0 }
+    } yield (d.toLong, c)
+
+    wordCounts
+  }
+
+  "Whitened M3" should "be correct" in {
+    val alpha: DenseVector[Double] = DenseVector[Double](5.0, 10.0, 20.0)
+    val allTokenDistributions: DenseMatrix[Double] = new DenseMatrix[Double](5, 3,
+      Array[Double](0.6, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.6, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.6))
+
+    val documents = simulateLDAData(
+      alpha,
+      allTokenDistributions,
+      numDocuments = 100,
+      numTokensPerDocument = 100
+    )
+    val documentsRDD = sc.parallelize(documents)
+
+    val cumulant = DataCumulant.getDataCumulant(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documentsRDD,
+      randomisedSVD = false
+    )
+
+    val expectedM3: DenseMatrix[Double] = expected_whitened_M3(
+      dimK = 3,
+      alpha0 = sum(alpha),
+      documents
+    )
+
+    TensorOps.dmatrixNorm(cumulant.thirdOrderMoments - expectedM3) should be <= 1e-6
+  }
+
+  private def expected_whitened_M3(dimK: Int,
+                                   alpha0: Double,
+                                   documents: Seq[(Long, SparseVector[Double])])
+                                  (implicit tolerance: Double = 1e-9)
+  : DenseMatrix[Double] = {
+    val v = documents map { _._2.toDenseVector }
+    val numDocs = v.length
+    val V = v.head.length
+
+    // Compute unshifted M1, M2, M3
+    val M1: DenseVector[Double] = v
+      .map { x => x / sum(x) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val E_x1_x2: DenseMatrix[Double] = v
+      .map { x => (x * x.t - diag(x)) / (sum(x) * (sum(x) - 1)) }
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    val seq_x1_x2_x3: Seq[DenseMatrix[Double]] = for {
+      c <- v
+      l = sum(c)
+
+      rawM3: DenseMatrix[Double] = DenseMatrix.zeros[Double](V, V * V)
+      fillM3 = for (i <- 0 until V; j <- 0 until V; k <- 0 until V) {
+        val j2 = k * V + j
+        rawM3(i, j2) = c(i) * c(j) * c(k)
+        if (i == j)
+          rawM3(i, j2) -= c(i) * c(k)
+        if (i == k)
+          rawM3(i, j2) -= c(i) * c(j)
+        if (j == k)
+          rawM3(i, j2) -= c(i) * c(j)
+        if (i == j && j == k)
+          rawM3(i, j2) += 2 * c(i)
+      }
+      m3 = rawM3 / (l * (l - 1) * (l - 2))
+    } yield m3
+
+    val E_x1_x2_x3 = seq_x1_x2_x3
+      .reduce(_ + _)
+      .map { _ / numDocs.toDouble }
+
+    // Compute shifted M2, M3
+    val (shiftedM2: DenseMatrix[Double], shiftedM3: DenseMatrix[Double]) = shiftMoments(M1, E_x1_x2, E_x1_x2_x3, alpha0)
+    val scaledShiftedM2 = shiftedM2 * alpha0 * (alpha0 + 1)
+    val scaledShiftedM3 = shiftedM3 * (alpha0 * (alpha0 + 1) * (alpha0 + 2) / 2.0)
+
+    // Eigendecomposition of shiftedM2
+    val eigSym.EigSym(sigma, u) = eigSym(scaledShiftedM2)
+    val i = argsort(sigma)
+    val (truncated_u: DenseMatrix[Double], truncated_sigma: DenseVector[Double]) = (
+      u(::, i.slice(V - dimK, V)).copy, sigma(i.slice(V - dimK, V)).copy)
+
+    // Whitening matrix
+    val W: DenseMatrix[Double] = truncated_u * diag(truncated_sigma map { x => 1 / (sqrt(x) + tolerance) })
+
+    // Whiten M3
+    val unfolded_whitenedM3: DenseMatrix[Double] = W.t * scaledShiftedM3 * kron(W.t, W.t).t
+
+    unfolded_whitenedM3
+  }
+
+
+  private def shiftMoments(M1: DenseVector[Double],
+                           M2: DenseMatrix[Double],
+                           M3: DenseMatrix[Double],
+                           alpha0: Double
+                          ): (DenseMatrix[Double], DenseMatrix[Double]) = {
+    val d: Int = M1.size
+    val kronM1: DenseMatrix[Double] = M1 * M1.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM2 = M2 - (alpha0 / (alpha0 + 1)) * kronM1
+
+    // We always unfold the 3rd-order tensors in matrix of size (d,d^2)
+    // G = E[x1 tensordot x2 tensordot M1] + E[x1 tensordot M1 tensordot x2]
+    // H = G + E[M1 tensordot x1 tensordot x2]
+    val G: Seq[DenseVector[Double]] = (0 until d) map { i =>
+      val kron = M1 * M2(i, ::)
+      (kron + kron.t).toDenseVector
+    }
+    val G2 = DenseMatrix.zeros[Double](d, d * M2.cols)
+    for (i <- 0 until d) {
+      G2(i, ::) := G(i).t
+    }
+    val H = G2 + M1 * M2.toDenseVector.t
+
+    // K = M1 tensordot M1 tensordot M1
+    val K = M1 * kronM1.toDenseVector.t
+
+    // [Anand14] Theorem 3.5
+    val shiftedM3 = M3 -
+      (alpha0 / (alpha0 + 2)) * H +
+      (2 * alpha0 * alpha0 / (alpha0 + 2) / (alpha0 + 1)) * K
+
+    (shiftedM2, shiftedM3)
+  }
+}


### PR DESCRIPTION
- I added the Apache 2.0 License file in the root directory (the license disclaimer to be added to each file later on)
- Refactored the non-sketching based code, added tests, remodelled the class interfaces, updated README for it
- Refactored away SparseVector distributed sum in the M1 calculation as large-scale computation on SparseVector seems to be fragile and fallible; now we always dissect a SparseVector/SparseMatrix and flat map out its elements/rows for any further Spark operations