### PR TITLE
Optimisations and tweaking

### DIFF
--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -56,7 +56,8 @@ class ALS(dimK: Int,
 
     println("Start ALS iterations...")
     var iter: Int = 0
-    while ((iter == 0) || ((iter < maxIterations) && !AlgebraUtil.isConverged(A_prev, A))) {
+    while ((iter == 0) ||
+      ((iter < maxIterations) && !AlgebraUtil.isConverged(A_prev, A)(dotThreshold = 0.999))) {
       A_prev = A.copy
 
       // println("Mode A...")

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/NonNegAdj.scala
@@ -9,9 +9,17 @@ import scala.language.postfixOps
 object NonNegativeAdjustment {
   def simplexProj_Matrix(M :DenseMatrix[Double]): DenseMatrix[Double] ={
     val M_onSimplex = DenseMatrix.zeros[Double](M.rows, M.cols)
+
     for(i <- 0 until M.cols optimized){
-      val (projectedVector, _) = simplexProj(M(::, i))
-      M_onSimplex(::, i) := projectedVector
+      val (projectedVector, theta) = simplexProj(M(::, i))
+      val (projectedVectorReversedSign, thetaReversedSign) = simplexProj(- M(::, i))
+
+      if (theta > thetaReversedSign) {
+        M_onSimplex(::, i) := projectedVector
+      }
+      else {
+        M_onSimplex(::, i) := projectedVectorReversedSign
+      }
     }
 
     M_onSimplex

--- a/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/utils/TensorOps.scala
@@ -1,12 +1,11 @@
 package edu.uci.eecs.spectralLDA.utils
 
-import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, max, norm}
+import breeze.linalg.{*, CSCMatrix, Counter, DenseMatrix, DenseVector, SparseVector, Tensor, norm}
 import breeze.math.{Complex, Semiring}
 import breeze.storage.Zero
 
 import scala.reflect.ClassTag
-import scalaxy.loops._
-import scala.language.postfixOps
+
 
 object TensorOps {
   /** Complex matrix norm */
@@ -42,26 +41,15 @@ object TensorOps {
   }
 
   /** makes 3rd-order rank-1 tensor $$x\otimes y\otimes z$$, returns the unfolded version */
-  def makeRankOneTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
-      (x: DenseVector[V], y: DenseVector[V], z: DenseVector[V]): DenseMatrix[V] = {
-    val d1 = x.length
-    val d2 = y.length
-    val d3 = z.length
-
-    val result = DenseMatrix.zeros[V](d1, d2 * d3)
-
-    val evV = implicitly[Numeric[V]]
-    import evV._
-
-    for (i <- 0 until d1 optimized) {
-      for (j <- 0 until d2 optimized) {
-        for (k <- 0 until d3 optimized) {
-          result(i, k * d2 + j) = x(i) * y(j) * z(k)
-        }
-      }
-    }
-
-    result
+  def makeRankOneTensor3d(x: DenseVector[Double],
+                          y: DenseVector[Double],
+                          z: DenseVector[Double]
+                         ): DenseMatrix[Double] = {
+    // This is a non-templated version of the function
+    // It seems Spark 2.0.0 worker nodes don't work correctly
+    // with the templated version of the function
+    val p = y * z.t
+    x * p.toDenseVector.t
   }
 
   /** Khatri-Rao product */

--- a/src/test/scala/edu/uci/eecs/spectralLDA/utils/TensorOpsTest.scala
+++ b/src/test/scala/edu/uci/eecs/spectralLDA/utils/TensorOpsTest.scala
@@ -1,0 +1,47 @@
+package edu.uci.eecs.spectralLDA.utils
+
+import breeze.linalg._
+import breeze.math.Semiring
+import breeze.storage.Zero
+import org.scalatest._
+
+import scala.reflect.ClassTag
+import scalaxy.loops._
+import scala.language.postfixOps
+
+
+class TensorOpsTest extends FlatSpec with Matchers {
+  def expectedRankOneTensor3d[@specialized(Double) V : ClassTag : Zero : Numeric : Semiring]
+    (x: DenseVector[V], y: DenseVector[V], z: DenseVector[V]): DenseMatrix[V] = {
+    val d1 = x.length
+    val d2 = y.length
+    val d3 = z.length
+
+    val result = DenseMatrix.zeros[V](d1, d2 * d3)
+
+    val evV = implicitly[Numeric[V]]
+    import evV._
+
+    for (i <- 0 until d1 optimized) {
+      for (j <- 0 until d2 optimized) {
+        for (k <- 0 until d3 optimized) {
+          result(i, k * d2 + j) = x(i) * y(j) * z(k)
+        }
+      }
+    }
+
+    result
+  }
+
+  "3rd-order vector outer product" should "be correct" in {
+    val x = DenseVector.rand[Double](50)
+    val y = DenseVector.rand[Double](50)
+    val z = DenseVector.rand[Double](50)
+
+    val tensor = TensorOps.makeRankOneTensor3d(x, y, z)
+    val expected = expectedRankOneTensor3d(x, y, z)
+
+    val diff = tensor - expected
+    norm(norm(diff(::, *)).toDenseVector) should be <= 1e-8
+  }
+}


### PR DESCRIPTION
We tweak the ALS convergence threshold, the l1-simplex projection, and refactor away the templated tensor product to leverage native BLAS. 

Next we're going to only keep non-sketching based code in the `master` branch; the sketching based code is in the `sketching` branch now.  