### PR TITLE
ALS eigenvectors orthogonality correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ val als = new ALS(
 
 // beta is the k-by-k matrix with $\beta_i$ as columns
 // alpha is the vector for $(\alpha_1,\ldots,\alpha_k)$
-val (beta: DenseMatrix[Double], alpha: DenseVector[Double]) = als.run
+val (beta: DenseMatrix[Double], _, _, alpha: DenseVector[Double]) = als.run
 ```
 
 ### Set up Spark 2.0.0 to use system native BLAS/LAPACK

--- a/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
@@ -1,5 +1,6 @@
 package edu.uci.eecs.spectralLDA
 
+import breeze.linalg.sum
 import org.apache.spark.{SparkConf, SparkContext}
 import edu.uci.eecs.spectralLDA.algorithm._
 import org.apache.spark.rdd._
@@ -40,7 +41,8 @@ object CVLogPerplexity {
     val augBeta = breeze.linalg.DenseMatrix.zeros[Double](beta.rows, k + 1)
     val augAlpha = breeze.linalg.DenseVector.ones[Double](alpha.length + 1)
     augBeta(::, 0 until k) := beta
-    augBeta(::, k) := m1
+    val dummyTopic = m1 + 0.1 * breeze.linalg.DenseVector.ones[Double](beta.rows) / beta.rows.toDouble
+    augBeta(::, k) := dummyTopic / sum(dummyTopic)
     augAlpha(0 until k) := alpha
 
     val tensorLDAModel = new TensorLDAModel(augBeta, augAlpha)

--- a/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
@@ -65,7 +65,7 @@ object CVLogPerplexity {
       .setMiniBatchFraction(0.05)
     val lda = new LDA()
       .setOptimizer(ldaOptimizer)
-      .setMaxIterations(60)
+      .setMaxIterations(80)
       .setK(k)
       .setDocConcentration(alpha0 / k.toDouble)
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/CVLogPerplexity.scala
@@ -65,7 +65,7 @@ object CVLogPerplexity {
       .setMiniBatchFraction(0.05)
     val lda = new LDA()
       .setOptimizer(ldaOptimizer)
-      .setMaxIterations(80)
+      .setMaxIterations(60)
       .setK(k)
       .setDocConcentration(alpha0 / k.toDouble)
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -141,8 +141,6 @@ class ALS(dimK: Int,
                                        B: DenseMatrix[Double],
                                        C: DenseMatrix[Double])
                                       (implicit
-                                       randBasis: RandBasis = Rand,
-                                       noisySGD: Boolean = true,
                                        penalty: Double = 10.0,
                                        step: Double = 1e-3,
                                        maxIter: Int = 100,
@@ -154,7 +152,6 @@ class ALS(dimK: Int,
 
     var i = 0
     val eyeK = DenseMatrix.eye[Double](dimK)
-    val gaussian = new Gaussian(mu = 0.0, sigma = 1.0)
 
     if (TensorOps.dmatrixNorm(updatedA.t * updatedA - eyeK) / dimK.toDouble > 1e-4) {
       while ((i == 0) || (i < maxIter &&
@@ -163,9 +160,7 @@ class ALS(dimK: Int,
 
         val h = eyeK + penalty * (orthoA.t * orthoA - eyeK)
         val grad = orthoA * h - updatedA
-        if (noisySGD) {
-          grad += DenseMatrix.rand[Double](dimK, dimK, gaussian) * 1e-6
-        }
+
         nextOrthoA = orthoA - step * grad
 
         i += 1

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -6,11 +6,9 @@ package edu.uci.eecs.spectralLDA.algorithm
 * Created by Furong Huang on 11/2/15.
 */
 
-import breeze.linalg.qr.QR
 import edu.uci.eecs.spectralLDA.utils.{AlgebraUtil, TensorOps}
 import breeze.linalg.{*, DenseMatrix, DenseVector, diag, max, min, norm, qr}
 import breeze.stats.distributions.{Gaussian, Rand, RandBasis}
-import sun.management.snmp.jvminstr.JvmThreadInstanceEntryImpl.ThreadStateMap.Byte0
 
 /** Tensor decomposition by Alternating Least Square (ALS)
   *

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -77,15 +77,15 @@ class ALS(dimK: Int,
         ((iter < maxIterations) && !AlgebraUtil.isConverged(A_prev, A)(dotThreshold = 0.999))) {
         A_prev = A.copy
 
-        val (updatedA, updatedLambda1) = updateOrthoALSIteration3(thirdOrderMoments, B, C)
+        val (updatedA, updatedLambda1) = updateALSIteration(thirdOrderMoments, B, C)
         A = updatedA
         lambda = updatedLambda1
 
-        val (updatedB, updatedLambda2) = updateOrthoALSIteration3(thirdOrderMoments, C, A)
+        val (updatedB, updatedLambda2) = updateALSIteration(thirdOrderMoments, C, A)
         B = updatedB
         lambda = updatedLambda2
 
-        val (updatedC, updatedLambda3) = updateOrthoALSIteration3(thirdOrderMoments, A, B)
+        val (updatedC, updatedLambda3) = updateALSIteration(thirdOrderMoments, A, B)
         C = updatedC
         lambda = updatedLambda3
 

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -118,6 +118,10 @@ class ALS(dimK: Int,
     (AlgebraUtil.matrixNormalization(updatedA), lambda)
   }
 
+  /** Eigenvectors orthogonality correction
+    *
+    * Not called by run() as they could cost the global convergence of ALS
+    */
   private def updateOrthoALSIteration1(unfoldedM3: DenseMatrix[Double],
                                        B: DenseMatrix[Double],
                                        C: DenseMatrix[Double])
@@ -128,6 +132,10 @@ class ALS(dimK: Int,
     (q, lambda)
   }
 
+  /** Eigenvectors orthogonality correction
+    *
+    * Not called by run() as they could cost the global convergence of ALS
+    */
   private def updateOrthoALSIteration2(unfoldedM3: DenseMatrix[Double],
                                        B: DenseMatrix[Double],
                                        C: DenseMatrix[Double])
@@ -137,6 +145,16 @@ class ALS(dimK: Int,
     (q, diag(r))
   }
 
+  /** Eigenvectors orthogonality correction via ADMM
+    *
+    * After the plain ALS update A^*, we try to minimize
+    *
+    *    min norm(a_i - a_i^*) + penalty * (a_i^T a_i - 1) ^2 + penalty * \sum_{j\neq i}(a_i^T a_j) ^ 2
+    *
+    * where a_i is the i-th row of A, a_i^* is the i-th row of A^*.
+    *
+    * Not called by run() as they could cost the global convergence of ALS
+    */
   private def updateOrthoALSIteration3(unfoldedM3: DenseMatrix[Double],
                                        B: DenseMatrix[Double],
                                        C: DenseMatrix[Double])

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -43,11 +43,12 @@ class ALS(dimK: Int,
     * Compute the best approximating rank-$k$ tensor $\sum_{i=1}^k\alpha_i\beta_i^{\otimes 3}$
     *
     * @param randBasis   default random seed
-    * @return            dimK-by-dimK matrix with all the $beta_i$ as columns,
+    * @return            three dimK-by-dimK matrices with all the $beta_i$ as columns,
     *                    length-dimK vector for all the eigenvalues
     */
   def run(implicit randBasis: RandBasis = Rand, restarts: Int = 5)
-     : (DenseMatrix[Double], DenseVector[Double])={
+     : (DenseMatrix[Double], DenseMatrix[Double],
+        DenseMatrix[Double], DenseVector[Double])={
     assert(restarts > 0, "Number of restarts for ALS must be positive.")
 
     val gaussian = Gaussian(mu = 0.0, sigma = 1.0)
@@ -111,7 +112,7 @@ class ALS(dimK: Int,
       }
     }
 
-    (optimalA, optimalLambda)
+    (optimalA, optimalB, optimalC, optimalLambda)
   }
 
   private def updateALSIteration(thirdOrderMoments: DenseMatrix[Double],

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -110,9 +110,9 @@ class ALS(dimK: Int,
     (optimalA, optimalB, optimalC, optimalLambda)
   }
 
-  private def updateALSIteration(thirdOrderMoments: DenseMatrix[Double],
-                                 B: DenseMatrix[Double],
-                                 C: DenseMatrix[Double]): DenseMatrix[Double] = {
-    thirdOrderMoments * TensorOps.krprod(C, B) * TensorOps.to_invert(C, B)
+  private def updateALSIteration(unfoldedM3: DenseMatrix[Double],
+                                  B: DenseMatrix[Double],
+                                  C: DenseMatrix[Double]): DenseMatrix[Double] = {
+    unfoldedM3 * TensorOps.krprod(C, B) * TensorOps.to_invert(C, B)
   }
 }

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/ALS.scala
@@ -59,20 +59,17 @@ class ALS(dimK: Int,
     var reconstructedLoss: Double = 0.0
     var optimalReconstructedLoss: Double = Double.PositiveInfinity
 
-    var A: DenseMatrix[Double] = DenseMatrix.zeros[Double](dimK, dimK)
-    var B: DenseMatrix[Double] = DenseMatrix.zeros[Double](dimK, dimK)
-    var C: DenseMatrix[Double] = DenseMatrix.zeros[Double](dimK, dimK)
-    var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
-    var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)
-
     for (s <- 0 until restarts) {
       val qr.QR(a0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
       val qr.QR(b0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
       val qr.QR(c0, _) = qr(DenseMatrix.rand[Double](dimK, dimK, gaussian))
 
-      A = a0
-      B = b0
-      C = c0
+      var A = a0
+      var B = b0
+      var C = c0
+
+      var A_prev = DenseMatrix.zeros[Double](dimK, dimK)
+      var lambda: breeze.linalg.DenseVector[Double] = DenseVector.zeros[Double](dimK)
 
       println("Start ALS iterations...")
       var iter: Int = 0

--- a/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
+++ b/src/main/scala/edu/uci/eecs/spectralLDA/algorithm/TensorLDA.scala
@@ -57,7 +57,7 @@ class TensorLDA(dimK: Int,
       maxIterations = maxIterations
     )
 
-    val (nu: DenseMatrix[Double], lambda: DenseVector[Double]) = myALS.run
+    val (nu: DenseMatrix[Double], _, _, lambda: DenseVector[Double]) = myALS.run
 
     // unwhiten the results
     // unwhitening matrix: $(W^T)^{-1}=U\Sigma^{1/2}$


### PR DESCRIPTION
We add three ways to correct eigenvectors orthogonality for the developer, two based on the QR decomposition, the third based on ADMM. They generally improve the log-perplexity by up to 0.04 but at the cost of the global convergence of the ALS algorithm. Currently `ALS.run()` still calls the update method with no orthogonality correction.